### PR TITLE
feat(process): gate-trio enforcement + branch/PR workflow (ADR-0013)

### DIFF
--- a/.claude/commands/close-step.md
+++ b/.claude/commands/close-step.md
@@ -1,0 +1,44 @@
+---
+description: EXIT gate — docs, ADRs, the validation gate (positive + negative), contracts, and ledgers all verified before a build unit is marked complete and PR'd.
+argument-hint: <build unit, e.g. "v0 Step 4" or "M1">
+---
+
+# /close-step — EXIT gate
+
+Gate the **completion** of a build unit. On PASS the unit is ready for its PR/merge — and **Checkpoint B (the merge/tag) stays with the human.** Sets the phase-index to ✅.
+
+**Build unit:** $ARGUMENTS
+
+Run **in order**. Report **PASS / FAIL / SKIP** for each. Any FAIL blocks the close.
+
+### Check 1 — Docs current (no drift)
+- Every doc the change touched is up to date: `docs/02-architecture.md` / `docs/04-v0-build-plan.md` / the ledgers / `CLAUDE.md` status. No doc still describes the old reality.
+- **FAIL** (name the stale doc) otherwise.
+
+### Check 2 — ADRs present
+- Every significant or irreversible decision in this unit has an ADR (with **rejected alternatives**) in `docs/adr/`, indexed in `docs/adr/README.md`.
+- **FAIL** if a decision is undocumented.
+
+### Check 3 — Validation gate run POSITIVE **and** NEGATIVE
+- The unit's validation-gate rows (e.g. VG1–VG8 for v0) are executed: the positive passes **and** the negative fires. Paste the evidence.
+- A gate not actually run is a **hard FAIL**.
+
+### Check 4 — No open errors
+- No `ERR-NNN` in `docs/ledgers/errors.md` owned by this unit is **Open** without an implemented prevention.
+- **FAIL** otherwise.
+
+### Check 5 — Interface contract verified + appended
+- This unit's *Consumes* matches the already-shipped *Produces* upstream; append this unit's *Produces* row to `docs/ledgers/interface-contracts.md`.
+- **FAIL** on any contract mismatch.
+
+### Check 6 — Phase index
+- Set the unit's row in `docs/ledgers/phase-index.md` to **✅**.
+
+## On PASS
+- Print: `<unit> is complete and verified. Open the PR — Checkpoint B (merge/tag) is the human's call.`
+
+## Allowed mutations
+ONLY: `docs/ledgers/interface-contracts.md` (append *Produces*) and `docs/ledgers/phase-index.md` (status → ✅). Nothing else.
+
+## Output
+A table — **Check | Status | Notes** — then the completion line, or every FAIL with its exact fix.

--- a/.claude/commands/review-step.md
+++ b/.claude/commands/review-step.md
@@ -1,0 +1,39 @@
+---
+description: CODE gate — run static analysis, secret scan, unit tests, and every negative case before a build unit can close. Read-only; reports, does not fix.
+argument-hint: <build unit, e.g. "v0 Step 4" or "M1">
+---
+
+# /review-step — CODE gate
+
+Gate the **code** of a build unit before it closes. Nothing here trusts that a check was *written* — it **runs** them.
+
+**Build unit:** $ARGUMENTS
+
+Run **in order**. Report **PASS / FAIL / SKIP** for each. This command is read-only — it reports, it does not fix.
+
+### Check 1 — Lint / static (behavioral)
+- `ruff check` and `ruff format --check` clean on the changed Python.
+- **FAIL** with the offending files otherwise.
+
+### Check 2 — Secret scan
+- No secret / API key / material in the diff or repo (run the pre-commit secret scan; review `git diff --staged`).
+- A *planted* fake key MUST be blocked — if the scan can't catch one, the scan is the bug.
+- **FAIL** if any secret-shaped string is staged.
+
+### Check 3 — Unit tests
+- `pytest` (unit) green for the unit's logic (e.g. normalization, fingerprint, score-output parsing, threshold routing, email rendering, `SearchSpec` validation).
+- **FAIL** with the failing test otherwise.
+
+### Check 4 — Every NEGATIVE case executed (the core)
+- For each validation-gate row of this unit, the **negative case is actually run** and the guard **fires** (e.g. malformed payload → rejected + logged, not silently persisted; threshold above all scores → valid "no matches" email, not a crash).
+- A negative case that was **not executed** is a **hard FAIL**.
+
+### Check 5 — No hardcoded config / secrets
+- Threshold, model id, query matrix, region, secret names come from config / `SearchSpec` / Secrets Manager — not literals in code.
+- **FAIL** (cite the line) otherwise.
+
+## Allowed mutations
+None — verification only.
+
+## Output
+A table — **Check | Status | Notes** — ending with `<unit> code gate: PASS — clear for /close-step.` or every FAIL with its exact fix.

--- a/.claude/commands/start-step.md
+++ b/.claude/commands/start-step.md
@@ -1,0 +1,41 @@
+---
+description: ENTRY gate — refuse to start a build unit until its spec is complete, prerequisites are closed, and every validation criterion is strong (behavioral + negative).
+argument-hint: <build unit, e.g. "v0 Step 4" or "M1">
+---
+
+# /start-step — ENTRY gate
+
+Gate the start of a **build unit** (a v0 Step or a migration). Refuse to begin implementation until the spec is complete and every validation criterion is *strong*. On PASS, ensure we are on a branch and set the phase-index to 🚧. This is the entry guardrail — most defects are cheapest to prevent here.
+
+**Build unit:** $ARGUMENTS
+
+Run the checks **in order**. Report **PASS / FAIL / SKIP** for each with a one-line note. Any FAIL blocks the unit from starting.
+
+### Check 1 — Spec is complete (behavioral)
+- The unit's scope + apply-step exists in `docs/04-v0-build-plan.md` (or the migration's just-in-time plan) with **WHY / WAIT-FOR / FAILURE-MODE**.
+- **FAIL** if any `[TO BE FILLED]` / `[TBD]` placeholder remains, or WAIT-FOR / FAILURE-MODE is missing.
+
+### Check 2 — Prerequisites closed
+- Everything the unit consumes is satisfied (e.g. the Secrets Manager secret exists; the upstream step's *Produces* is in `docs/ledgers/interface-contracts.md`; required `D-…` / ADR sub-decisions are resolved).
+- **FAIL** (name the open prerequisite) otherwise.
+
+### Check 3 — Deferred procedures authored
+- Any procedure marked `Deferred → <this unit>` in `docs/ledgers/procedure-registry.md` is now **Written**.
+- **FAIL** if a procedure this unit owes is still Deferred.
+
+### Check 4 — Every validation criterion is STRONG (the gate-robustness standard)
+- Each of the unit's validation-gate rows is **behavioral** (asserts the thing does its job through its real interface) **and** carries a **negative case** (or `Negative case: N/A — <reason>`).
+- A presence/liveness-only criterion, or a missing negative case, is a **hard FAIL** (a weak gate reports green on a broken system — worse than none).
+
+### Check 5 — On a branch
+- We are **not** on `main`. If on `main`, create `feat/<unit-slug>` (or `chore/<slug>`) and switch to it.
+
+## On PASS
+- Set the unit's row in `docs/ledgers/phase-index.md` to **🚧**.
+- Print: `<unit> is cleared to implement. Checkpoint A (spec approved) is the human's call.`
+
+## Allowed mutations
+ONLY: `docs/ledgers/phase-index.md` (status → 🚧) and creating the git branch. Nothing else.
+
+## Output
+A table — **Check | Status | Notes** — then the clearance line, or every FAIL with its exact fix.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@ JobFetcher is a personal-scale, serverless job-matching tool **and** a Data-Engi
 - **Decision rights:** Tarig approves architecture + major/irreversible decisions; Claude drives the rest and documents it. **Confirm major decisions only** — don't stop every step, don't barrel through irreversible ones.
 - **Safety-first (Castle Principle):** build don't demolish · smallest change that works · one change at a time · verify before *and* after · **document before you delete** · **destructive ops (rm, DROP, terraform destroy, force-push) require explicit approval.**
 - **AWS dev identity:** all local development uses the non-root **`jobfetcher-dev`** IAM user (CLI profile `jobfetcher`, also the `[default]`), region **us-east-1**; the keyless **root** session (`samareltayeb`) is for *rare root-only ops only*; **CI/CD and Lambda runtime get their own least-privilege IAM roles — never the personal key.** Full model in [`docs/ledgers/decisions-locked.md`](docs/ledgers/decisions-locked.md).
+- **Build workflow ([ADR-0013](docs/adr/0013-enforcement-gate-trio-branch-pr.md)):** each build unit runs the **gate trio** — `/start-step` (entry) → implement → `/review-step` (code) → `/close-step` (exit) — with **two human checkpoints** (spec approved *before* code; approval *before* merge/tag). v0 *code* builds on a branch → PR → tag; `main` is PR-only (docs may go direct for speed).
 - **Documentation is constructed, not described** — written live as decisions happen, not reconstructed later. Every doc carries **What / Why / So-what**. A `[TO BE FILLED]` placeholder is a blocker, not a draft.
 - **Decisions → ADRs** ([`docs/adr/`](docs/adr/)) with the rejected alternatives named. Errors → the error log ([`docs/ledgers/errors.md`](docs/ledgers/errors.md)) answering the Five Questions (what/why/how/fix/prevention+detection).
 - **Testing:** unit (logic) + integration (LocalStack/moto) + dbt tests (marts) + a live smoke run. Validation gates are **behavioral + carry a negative case** — a presence/liveness check is *no gate*.
@@ -51,7 +52,7 @@ Two planes (full detail in [`docs/02-architecture.md`](docs/02-architecture.md))
 ## What NOT to do
 - Don't build ahead of the current stage. v0 first; migrations are planned **just-in-time** after the prior release ships.
 - Don't add a service/tool/library that can't pass the defensibility rubric. If it's a showcase, label it one.
-- Don't pre-decide the gate-enforcement machinery (slash-commands vs Makefile vs checklists) — that's evaluated during implementation.
+- Don't commit v0 *code* directly to `main` — branch → PR → merge after the gate trio passes ([ADR-0013](docs/adr/0013-enforcement-gate-trio-branch-pr.md)); docs may go direct for speed.
 - Don't put real PII (CV/profile) in the repo — sanitized sample only; real data is gitignored and lives in private S3.
 - Don't claim scale justifies the stack — it doesn't (10–30 jobs/day). Defend on *patterns at production standard, modest scale, deliberately right-sized.*
 - Don't let a doc go stale after a change — update it the moment the change is made.

--- a/docs/05-methodology.md
+++ b/docs/05-methodology.md
@@ -35,8 +35,23 @@ Each cut is **labeled "deferred → adopt when X"**, never silently dropped — 
 
 ---
 
-## Enforcement is emergent (Tarig)
-We do **not** pre-decide the gate machinery. v0's "process" is **the docs + manual discipline** (apply-sequence, validation gate, ADRs, error log). Whether the gates become **Claude Code slash-commands**, **Makefile targets**, or stay **manual checklists** is **evaluated during implementation** and adopted only when a real need justifies it — [P1/P2](00-design-philosophy.md) applied to the process itself. (We're working inside Claude Code, so slash-commands are near-free if/when we want them — a candidate, not a commitment.)
+## Enforcement — the gate trio ([ADR-0013](adr/0013-enforcement-gate-trio-branch-pr.md))
+The "emergent" machinery decision is now **made** — the trigger (building, inside Claude Code where a command is near-free) is met. The enforcement surface is **three committed Claude Code slash-commands** ([`.claude/commands/`](../.claude/commands/)), one per gate (the methodology *wired in*, not just written):
+- **`/start-step`** (ENTRY) — refuses to start a build unit until its spec is complete, prereqs are closed, deferred procedures are authored, and **every validation criterion is strong** → sets 🚧.
+- **`/review-step`** (CODE) — lint · secret scan · unit tests · **every negative case actually executed** · no hardcoded config.
+- **`/close-step`** (EXIT) — docs current · ADRs present · validation gate positive+negative · no open errors · contract verified + *Produces* appended → sets ✅.
+
+**Two human checkpoints** bracket every unit: **A** — spec/plan approved *before* code (= plan mode); **B** — approval *before* the irreversible merge/tag. **Git workflow:** v0 *code* builds on a per-migration branch → self-reviewed PR (+ CI from Step 9) → tag; `main` is PR-only (docs may stay direct for speed).
+
+**The gate-robustness standard** (self-applied by the commands): a criterion that checks only existence/liveness is **no gate** — it reports green on a broken system. Every criterion must be *behavioral* + carry a *negative case* (or `N/A — reason`):
+
+| Weak (presence / liveness) | Robust (behavioral) |
+|---|---|
+| Container is `running` | INSERT a row, SELECT it back — the value matches |
+| Port is open | Produce a message, consume it, payload decodes against the schema |
+| HTTP 200 returned | Response body matches the declared schema field-for-field |
+
+Still **not** adopted (coordination/scale ceremony — deferred, labeled): the full 10-command catalog (scaffolders, `/audit-foundation`), per-phase doc ceremony, the six-angle chaos matrix, an external-reviewer *hard* gate.
 
 ## Documentation system summary (what lives where)
 | Layer | Where | Updated |

--- a/docs/adr/0013-enforcement-gate-trio-branch-pr.md
+++ b/docs/adr/0013-enforcement-gate-trio-branch-pr.md
@@ -1,0 +1,23 @@
+# ADR-0013 — Enforcement machinery: gate-trio slash-commands + branch/PR workflow
+
+## Status
+Accepted
+
+## Context
+[05-methodology](../05-methodology.md) deferred the gate-enforcement *machinery* (slash-commands vs Makefile vs checklists) as **emergent** — to decide "when a real need justifies it." Two triggers are now met: we are crossing from design into **building** v0, and we work **inside Claude Code**, where a slash-command is near-free. Tarig's **Master Project Implementation Plan** frames the rule: *a standard not wired into a command is a suggestion* — the system should be *unable to proceed* until a gate has actually run. We already adopted that plan's core (ledgers, ADRs, the behavioral-gate standard = VG1–8); this records the enforcement *surface* + the dev workflow.
+
+## Decision
+1. **The gate trio as Claude Code slash-commands** (`.claude/commands/`, committed): **`/start-step`** (ENTRY — spec complete, prereqs closed, every criterion strong → 🚧), **`/review-step`** (CODE — lint, secret scan, unit tests, every negative case executed), **`/close-step`** (EXIT — docs, ADRs, validation gate positive+negative, contracts, no open errors → ✅). Each self-applies the **gate-robustness standard** (behavioral + a negative case, or `N/A — reason`).
+2. **Branch + PR + protected `main`** for v0 *code*: build on a per-migration branch → self-reviewed PR (+ CI when it lands at Step 9) → tag the release; `main` is PR-only. (Docs may stay direct for iteration speed.)
+3. **Two human checkpoints:** **A** = spec/plan approved before code (= plan mode); **B** = approval before the irreversible merge/tag.
+
+## Alternatives Considered
+- **Manual checklists only** (the prior "emergent" default). Rejected *now*: the build is starting and a command in Claude Code costs ~0; a written-only checklist is the "suggestion" the Master Plan warns about — silently skippable.
+- **A lean 1–2 commands** (just `/verify`). Rejected: the *entry* gate (refuse code until the spec/criteria are strong) prevents the cheapest-to-fix defects; dropping it keeps the weakest link.
+- **The full 10-command catalog** (`/new-phase`, `/write-adr`, `/run-chaos`, `/audit-foundation`, …). Rejected for now: scaffolders + a standing audit are coordination/scale ceremony; the 3 gates carry the airtight core. They stay optional follow-ons.
+- **Direct-to-main** (status quo). Rejected for code: no pre-merge gate, and it conflicts with "each migration = a clean, reviewable release."
+
+## Consequences
+- **Easier:** a gate can't be silently skipped — it runs and prints PASS/FAIL; Checkpoint B has a natural home (the PR merge); the committed commands are a portfolio signal (the methodology is *wired in*, not just described).
+- **Harder:** slightly more ceremony per unit (three commands; a branch). Mitigated by keeping to the 3 gates (not 10) and self-review (no external-reviewer hard gate).
+- **Impact:** supersedes the "enforcement is emergent / don't pre-decide" note in [05-methodology](../05-methodology.md) + CLAUDE.md; `procedure-registry` marks the gate commands **Written**; the six-angle chaos matrix + scaffolder commands stay deferred.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -18,5 +18,6 @@ These are the **foundational** decisions made during the design session — the 
 | [0010](0010-job-source-jsearch.md) | Job source: JSearch (probe-free → Pro), single-source for v0; Adzuna deferred | Accepted |
 | [0011](0011-dimensional-analytical-model.md) | Analytical model: insight-driven dimensional (constellation) schema; grow per question | Accepted |
 | [0012](0012-model-agnostic-llm.md) | Model-agnostic LLM via Bedrock Converse; model id in config (swap models freely) | Accepted |
+| [0013](0013-enforcement-gate-trio-branch-pr.md) | Enforcement: gate-trio slash-commands (`/start-step` · `/review-step` · `/close-step`) + branch/PR workflow | Accepted |
 
 > Full reasoning narrative: [01-session-decision-journal](../01-session-decision-journal.md). Crisp decision list: [ledgers/decisions-locked](../ledgers/decisions-locked.md).

--- a/docs/ledgers/phase-index.md
+++ b/docs/ledgers/phase-index.md
@@ -1,6 +1,6 @@
 # Ledger · Phase Index
 
-> Live source of truth for progress. Status legend: ⬜ not started · 🚧 in progress · ✅ shipped (tagged release). The roadmap beyond v0 is a **[living hypothesis](../03-roadmap.md)** — re-derived after each release; update this table as reality unfolds.
+> Live source of truth for progress. Status legend: ⬜ not started · 🚧 in progress · ✅ shipped (tagged release). `/start-step` sets 🚧, `/close-step` sets ✅ ([ADR-0013](../adr/0013-enforcement-gate-trio-branch-pr.md)). The roadmap beyond v0 is a **[living hypothesis](../03-roadmap.md)** — re-derived after each release; update this table as reality unfolds.
 
 **Current state:** **v0 in progress — Step 0 (ingestion coverage probe).** Design + docs complete. First code exists: a validated, `SearchSpec`-driven JSearch probe ([`scripts/jsearch_probe.py`](../../scripts/jsearch_probe.py)) proven end-to-end against the live API; JSearch key in Secrets Manager; chosen LLM = Kimi K2 Thinking. **Blocker:** account-wide Bedrock daily-token quota = 0 ([ERR-001](errors.md)) gates the scoring path. Full 18-query sweep + v0 build steps 1+ are next.
 

--- a/docs/ledgers/procedure-registry.md
+++ b/docs/ledgers/procedure-registry.md
@@ -8,6 +8,7 @@
 | Error/incident logging (Five Questions) | ✅ Written | [05-methodology](../05-methodology.md#adopt-cheap-high-leverage-even-solo--value-is-memory-across-time) + [errors.md](errors.md) |
 | Validation-gate standard (behavioral + negative case) | ✅ Written | [05-methodology](../05-methodology.md) + applied in [04-v0-build-plan](../04-v0-build-plan.md) |
 | Secrets management (Secrets Manager, `jobfetcher/<service>`) | ✅ Written | [decisions-locked](decisions-locked.md) (Security) · pattern in [`scripts/jsearch_probe.py`](../../scripts/jsearch_probe.py) `get_key()` |
+| **Gate trio** (entry/code/exit) as slash-commands | ✅ Written | [`.claude/commands/`](../../.claude/commands/) (`start-step` · `review-step` · `close-step`) · [ADR-0013](../adr/0013-enforcement-gate-trio-branch-pr.md) |
 | Data-contract / source normalization | 🟡 Started → v0 | `SearchSpec` ([scripts/search_spec.py](../../scripts/search_spec.py)) is the first; posting/score contracts at build Step 2 |
 | Scoring-prompt standard (7-factor, explainable, temp 0) | 🔜 Deferred → v0 | authored in v0 Step 5 |
 | Migratability checklist (ports/adapters, flags, Alembic, additive TF) | ✅ Written | [03-roadmap](../03-roadmap.md#migratability-requirements-build-v0-so-the-above-stays-cheap) |


### PR DESCRIPTION
Adopts the delta from the Master Project Implementation Plan, right-sized (ADR-0013).

## What this adds
- **Gate trio** as committed Claude Code slash-commands (`.claude/commands/`): `/start-step` (entry), `/review-step` (code), `/close-step` (exit) — each self-applies the behavioral-gate standard (behavioral + a negative case).
- **Two human checkpoints**: A (spec/plan approved before code = plan mode); B (approval before merge/tag — i.e. *this merge*).
- **Branch + PR + protected `main`** for v0 code (this PR dogfoods it).

## Docs
ADR-0013 (decision + rejected alternatives); 05-methodology (enforcement emergent → adopted + weak/robust table); CLAUDE.md, procedure-registry, phase-index, adr/README.

## Not adopted (still cut)
Full 10-command catalog, per-phase ceremony, six-angle chaos matrix, external-reviewer hard gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a three-gate enforcement workflow (entry, code review, completion) to validate build units through sequential automated checks.
  * Added human approval checkpoints at critical phases before code execution and irreversible merge/release operations.

* **Documentation**
  * Updated methodology and added decision record documenting the gate-based enforcement workflow and standardized development process using branches and pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->