### PR TITLE
fix(deploy): Aurora Data API bugs caught by the live Step-10 deploy + Lambda timeout

### DIFF
--- a/migrations/env.py
+++ b/migrations/env.py
@@ -20,7 +20,9 @@ config = context.config
 # Resolve the DB URL from the environment and inject it (so alembic.ini holds no credential).
 _db = DbConfig.from_env()
 if _db is not None:
-    config.set_main_option("sqlalchemy.url", _db.connection_url)
+    # Escape `%` for configparser interpolation: the Aurora Data API URL carries `%`-encoded
+    # ARNs (e.g. `%3A`), which `set_main_option` would otherwise read as interpolation syntax.
+    config.set_main_option("sqlalchemy.url", _db.connection_url.replace("%", "%%"))
 
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)

--- a/src/jobfetcher/handlers/pipeline.py
+++ b/src/jobfetcher/handlers/pipeline.py
@@ -92,7 +92,9 @@ def resolve_db_url(env: dict[str, str]) -> str:
             "no DB connection configured — set $JOBFETCHER_DB_URL (local) or all of "
             f"${_DB_CLUSTER_ARN_ENV}/${_DB_SECRET_ARN_ENV}/${_DB_NAME_ENV} (Aurora Data API)"
         )
-    params = urllib.parse.urlencode({"cluster_arn": cluster_arn, "secret_arn": secret_arn})
+    # The sqlalchemy-aurora-data-api dialect maps query params straight to its `connect()` kwargs,
+    # whose name is `aurora_cluster_arn` (not `cluster_arn`) — verified live in the Step-10 deploy.
+    params = urllib.parse.urlencode({"aurora_cluster_arn": cluster_arn, "secret_arn": secret_arn})
     return f"postgresql+auroradataapi://:@/{db_name}?{params}"
 
 

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -33,7 +33,8 @@ resource "aws_lambda_function" "pipeline" {
   filename         = data.archive_file.lambda.output_path
   source_code_hash = data.archive_file.lambda.output_base64sha256
 
-  timeout     = 300 # 5 min — daily batch with LLM calls + ~15s Aurora cold-resume
+  timeout     = 900 # 15 min (max) — each posting is an LLM dissect/score + a Data-API write
+  # (~30s over the network), so the daily batch needs real headroom (vs the Aurora cold-resume too).
   memory_size = 512
 
   # Config only — NO secret VALUES. The handler fetches secret values at runtime

--- a/tests/test_handler_helpers.py
+++ b/tests/test_handler_helpers.py
@@ -39,8 +39,9 @@ def test_resolve_db_url_builds_data_api_url_from_arns():
     }
     url = resolve_db_url(env)
     assert url.startswith("postgresql+auroradataapi://:@/jobfetcher?")
-    # the ARNs are carried as url-encoded query params
-    assert "cluster_arn=arn%3Aaws%3Ards%3Aus-east-1%3A1%3Acluster%2Fjf" in url
+    # the ARNs are carried as url-encoded query params; the cluster param is the dialect's
+    # `aurora_cluster_arn` connect kwarg (verified live in the Step-10 deploy)
+    assert "aurora_cluster_arn=arn%3Aaws%3Ards%3Aus-east-1%3A1%3Acluster%2Fjf" in url
     assert "secret_arn=arn%3Aaws%3Asecretsmanager%3Aus-east-1%3A1%3Asecret%2Fjf" in url
 
 


### PR DESCRIPTION
The first real `terraform apply` + live invocation (Step 10) surfaced two bugs on the **Aurora Data API** path — invisible to local tests (psycopg2) and CI (postgres service). Both fixed and **validated live**.

## Fixes
- **`migrations/env.py`** — `set_main_option` passed the Data API URL through configparser, whose interpolation choked on the `%`-encoded ARNs (`%3A`). Escape `%` → `%%` (the standard fix). Without it, `alembic upgrade head` against Aurora fails.
- **`handlers/pipeline.py`** — `resolve_db_url` built the URL with `cluster_arn=`, but the `sqlalchemy-aurora-data-api` dialect maps query params to its `connect()` kwargs, whose name is **`aurora_cluster_arn`**. Wrong name → `connect() got an unexpected keyword argument 'cluster_arn'` → **would break every deploy** (the Lambda hit it too). Fixed + the helper test updated to assert the correct param.
- **`terraform/lambda.tf`** — timeout `300 → 900` (max). Each posting is an LLM dissect/score + a Data-API write (~30s over the network); 5 min lacked headroom for the daily batch.

## Validated live (Step 10)
Schema created on Aurora via the Data API; the Lambda ran the full pipeline end-to-end — **fetch 10 → dissect 8 → gold 8 → score 8 → SES email** — `statusCode 200`, **two emails delivered** (a no-matches digest + a populated 7-job shortlist), `run_log` send-once + idempotent re-run confirmed. Infra then destroyed to $0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)