### PR TITLE
fix(llm): M1/H-1 — retry transient provider failures + symmetric failure isolation

### DIFF
--- a/src/jobfetcher/adapters/llm_openai.py
+++ b/src/jobfetcher/adapters/llm_openai.py
@@ -6,18 +6,31 @@ provider-specific JSON mode, so this stays portable (ADR-0012). The key comes fr
 `$DEEPSEEK_API_KEY` (tests) or Secrets Manager (runtime) and is never logged.
 
 Stdlib `urllib` only — no HTTP dependency.
+
+Transient provider failures (429 / 5xx / connection errors) are retried with exponential
+backoff + full jitter, per `LlmConfig.max_retries` (ERR-006: one DeepSeek 503 must not kill
+a run). Auth and model-not-found errors always fail fast — retrying them is pure waste.
 """
 from __future__ import annotations
 
 import json
+import logging
 import os
+import random
+import time
 import urllib.error
 import urllib.request
 
 from ..config import LlmConfig
 from ..core.ports import LlmAuthError, LlmError, LlmModelNotFoundError
 
+log = logging.getLogger(__name__)
+
 _ENV_KEY = "DEEPSEEK_API_KEY"
+
+# HTTP statuses worth retrying: rate limit + server-side/transient. Everything else 4xx is a
+# request problem that a retry cannot fix.
+_RETRYABLE_STATUSES = frozenset({429, 500, 502, 503, 504})
 
 
 def _resolve_api_key(config: LlmConfig) -> str:
@@ -78,21 +91,44 @@ class OpenAICompatLlmClient:
             },
             method="POST",
         )
-        try:
-            with urllib.request.urlopen(req, timeout=self.config.timeout_s) as resp:
-                data = json.loads(resp.read())
-        except urllib.error.HTTPError as e:
-            detail = e.read().decode(errors="replace")[:500]
-            low = detail.lower()
-            if e.code == 401:
-                raise LlmAuthError(f"401 Unauthorized: {detail}") from e
-            if e.code == 404 or ("model" in low and "not" in low):
-                raise LlmModelNotFoundError(f"model '{self.config.model}': {detail}") from e
-            raise LlmError(f"HTTP {e.code}: {detail}") from e
-        except urllib.error.URLError as e:  # connection / timeout
-            raise LlmError(f"connection error to {self.config.base_url}: {e}") from e
-
+        data = self._request_with_retries(req)
         try:
             return data["choices"][0]["message"]["content"] or ""
         except (KeyError, IndexError, TypeError) as e:
             raise LlmError(f"unexpected response shape: {json.dumps(data)[:300]}") from e
+
+    def _request_with_retries(self, req: urllib.request.Request) -> dict:
+        """One HTTP round-trip, retrying ONLY transient failures (429/5xx/connection) with
+        exponential backoff + full jitter. 401/404/other-4xx fail fast on the first attempt."""
+        attempts = self.config.max_retries + 1
+        last_transient: LlmError | None = None
+        for attempt in range(attempts):
+            if attempt:  # back off before every retry (never before the first attempt)
+                delay = random.uniform(0, self.config.backoff_base_s * 2 ** (attempt - 1))
+                log.warning(
+                    "transient LLM failure (%s) — retry %d/%d after %.1fs",
+                    last_transient,
+                    attempt,
+                    self.config.max_retries,
+                    delay,
+                )
+                time.sleep(delay)
+            try:
+                with urllib.request.urlopen(req, timeout=self.config.timeout_s) as resp:
+                    return json.loads(resp.read())
+            except urllib.error.HTTPError as e:
+                detail = e.read().decode(errors="replace")[:500]
+                low = detail.lower()
+                if e.code == 401:
+                    raise LlmAuthError(f"401 Unauthorized: {detail}") from e
+                if e.code == 404 or ("model" in low and "not" in low):
+                    raise LlmModelNotFoundError(f"model '{self.config.model}': {detail}") from e
+                err = LlmError(f"HTTP {e.code}: {detail}")
+                if e.code not in _RETRYABLE_STATUSES:
+                    raise err from e
+                last_transient = err
+            except urllib.error.URLError as e:  # connection / timeout — transient
+                last_transient = LlmError(f"connection error to {self.config.base_url}: {e}")
+        raise LlmError(
+            f"still failing after {self.config.max_retries} retries: {last_transient}"
+        ) from last_transient

--- a/src/jobfetcher/config.py
+++ b/src/jobfetcher/config.py
@@ -24,6 +24,10 @@ class LlmConfig(BaseModel):
     temperature: float = Field(default=0.0, ge=0.0, le=2.0)
     max_tokens: int = Field(default=4096, ge=1)
     timeout_s: float = Field(default=60.0, gt=0.0)
+    # Transient-failure policy (ERR-006): retries apply ONLY to 429/5xx/connection errors —
+    # auth (401) and model-not-found (404) always fail fast. 0 disables retrying.
+    max_retries: int = Field(default=3, ge=0)
+    backoff_base_s: float = Field(default=1.0, gt=0.0)
 
 
 _DB_URL_ENV = "JOBFETCHER_DB_URL"

--- a/src/jobfetcher/core/ingest.py
+++ b/src/jobfetcher/core/ingest.py
@@ -126,9 +126,11 @@ def land_silver(
         meta.location,
     )
 
+    # Failure isolation is symmetric with `score_gold` (ERR-006): a provider-level LlmError
+    # (e.g. a 503 that outlived the client's retries) skips THIS posting, never the run.
     try:
         dissected = dissector.dissect(jd, meta)
-    except DissectionError as exc:
+    except (DissectionError, LlmError) as exc:
         log.warning("dissection failed for %s (run_id=%s): %s", bronze_id, run_id, exc)
         return None
     return repo.save_posting(

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from jobfetcher.core.dissector import Dissector, DissectionError
 from jobfetcher.core.ingest import fetch_to_bronze, ingest, land_silver
+from jobfetcher.core.ports import LlmError
 from jobfetcher.core.search_spec import SearchSpec
 from tests.helpers import CANNED_LLM_JSON, FakeLlm
 
@@ -206,6 +207,24 @@ def test_land_silver_skips_on_dissection_error():
     class _D(Dissector):
         def dissect(self, jd_text, metadata):
             raise DissectionError("forced")
+
+    pid = land_silver(
+        "jsearch:a", _job("a"), run_id="r", source="jsearch", source_job_id="a",
+        dissector=_D(FakeLlm()), repo=repo,
+    )
+    assert pid is None
+    assert repo.postings == {}
+
+
+def test_land_silver_skips_on_llm_error():
+    # ERR-006 negative: a provider-level LlmError (a 503 that outlived the client retries)
+    # must be isolated exactly like a DissectionError — skip the posting, never crash the
+    # run. (Before H-1 this propagated and killed the whole pipeline — seen live.)
+    repo = FakeRepo()
+
+    class _D(Dissector):
+        def dissect(self, jd_text, metadata):
+            raise LlmError("HTTP 503: service busy")
 
     pid = land_silver(
         "jsearch:a", _job("a"), run_id="r", source="jsearch", source_job_id="a",

--- a/tests/test_llm_openai.py
+++ b/tests/test_llm_openai.py
@@ -29,6 +29,10 @@ def _client():
     return OpenAICompatLlmClient(LlmConfig(), api_key="test-key")
 
 
+def _no_retry_client():
+    return OpenAICompatLlmClient(LlmConfig(max_retries=0), api_key="test-key")
+
+
 def _raise_http(code: int, body: str):
     def _u(req, timeout=0):
         raise urllib.error.HTTPError(
@@ -59,7 +63,7 @@ def test_model_not_found(monkeypatch):
 def test_500_maps_to_llm_error(monkeypatch):
     monkeypatch.setattr(llm_openai.urllib.request, "urlopen", _raise_http(500, "server boom"))
     with pytest.raises(LlmError):
-        _client().complete(system="s", user="u")
+        _no_retry_client().complete(system="s", user="u")
 
 
 def test_no_key_raises_auth(monkeypatch):
@@ -84,6 +88,108 @@ def _capture_payload(monkeypatch) -> dict:
 
     monkeypatch.setattr(llm_openai.urllib.request, "urlopen", _fake_urlopen)
     return captured
+
+
+# --------------------------------------------------------------------- retry policy (ERR-006)
+class _FlakyThenOk:
+    """urlopen fake: raise the given HTTP errors in order, then return a good completion."""
+
+    def __init__(self, *codes: int):
+        self.codes = list(codes)
+        self.calls = 0
+
+    def __call__(self, req, timeout=0):
+        self.calls += 1
+        if self.codes:
+            code = self.codes.pop(0)
+            raise urllib.error.HTTPError(
+                "http://x/chat/completions", code, "err", None, io.BytesIO(b"busy")
+            )
+        return _FakeResp({"choices": [{"message": {"content": "recovered"}}]})
+
+
+def _no_sleep(monkeypatch) -> list[float]:
+    """Neutralize the backoff sleep; return the list of requested delays."""
+    delays: list[float] = []
+    monkeypatch.setattr(llm_openai.time, "sleep", delays.append)
+    return delays
+
+
+def test_transient_503_is_retried_to_success(monkeypatch):
+    """ERR-006 positive: two 503s then a 200 → the call succeeds, with backoff in between."""
+    delays = _no_sleep(monkeypatch)
+    fake = _FlakyThenOk(503, 503)
+    monkeypatch.setattr(llm_openai.urllib.request, "urlopen", fake)
+    assert _client().complete(system="s", user="u") == "recovered"
+    assert fake.calls == 3
+    assert len(delays) == 2  # one backoff before each retry
+
+
+def test_retries_exhausted_raises_llm_error(monkeypatch):
+    """ERR-006 negative: a persistent 503 fails after exactly max_retries retries."""
+    _no_sleep(monkeypatch)
+    fake = _FlakyThenOk(503, 503, 503, 503, 503)
+    monkeypatch.setattr(llm_openai.urllib.request, "urlopen", fake)
+    with pytest.raises(LlmError, match="after 3 retries"):
+        _client().complete(system="s", user="u")
+    assert fake.calls == 4  # 1 attempt + max_retries(3)
+
+
+def test_auth_error_is_never_retried(monkeypatch):
+    """A 401 is a config problem — retrying it is waste. Exactly one attempt."""
+    delays = _no_sleep(monkeypatch)
+    fake = _FlakyThenOk(401, 401)
+    monkeypatch.setattr(llm_openai.urllib.request, "urlopen", fake)
+    with pytest.raises(LlmAuthError):
+        _client().complete(system="s", user="u")
+    assert fake.calls == 1
+    assert delays == []
+
+
+def test_non_retryable_4xx_fails_fast(monkeypatch):
+    """A 400 (bad request) is not transient — no retry."""
+    _no_sleep(monkeypatch)
+    fake = _FlakyThenOk(422)
+    monkeypatch.setattr(llm_openai.urllib.request, "urlopen", fake)
+    with pytest.raises(LlmError):
+        _client().complete(system="s", user="u")
+    assert fake.calls == 1
+
+
+def test_connection_error_is_retried(monkeypatch):
+    """URLError (network blip / timeout) counts as transient."""
+    _no_sleep(monkeypatch)
+    calls = {"n": 0}
+
+    def _flaky(req, timeout=0):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise urllib.error.URLError("connection reset")
+        return _FakeResp({"choices": [{"message": {"content": "back"}}]})
+
+    monkeypatch.setattr(llm_openai.urllib.request, "urlopen", _flaky)
+    assert _client().complete(system="s", user="u") == "back"
+    assert calls["n"] == 2
+
+
+def test_backoff_delays_grow_exponentially(monkeypatch):
+    """Full jitter: each delay is uniform(0, base * 2^(attempt-1)) — bounds must grow."""
+    monkeypatch.setattr(llm_openai.random, "uniform", lambda a, b: b)  # take the upper bound
+    delays = _no_sleep(monkeypatch)
+    fake = _FlakyThenOk(503, 503, 503, 503)
+    monkeypatch.setattr(llm_openai.urllib.request, "urlopen", fake)
+    with pytest.raises(LlmError):
+        _client().complete(system="s", user="u")
+    assert delays == [1.0, 2.0, 4.0]  # backoff_base_s=1.0 doubling per retry
+
+
+def test_max_retries_zero_disables_retrying(monkeypatch):
+    _no_sleep(monkeypatch)
+    fake = _FlakyThenOk(503, 503)
+    monkeypatch.setattr(llm_openai.urllib.request, "urlopen", fake)
+    with pytest.raises(LlmError):
+        _no_retry_client().complete(system="s", user="u")
+    assert fake.calls == 1
 
 
 @pytest.mark.parametrize("temp", [0.0, 0.7])


### PR DESCRIPTION
## The bottleneck (measured live, P2 run 2026-07-02)

One DeepSeek `HTTP 503: Service is too busy` killed an entire pipeline run:
1. `OpenAICompatLlmClient.complete()` made exactly **one** HTTP attempt — any 5xx raised `LlmError` immediately.
2. **Asymmetric isolation:** `score_gold` catches `(ScorerError, LlmError)` per item, but `land_silver` only caught `DissectionError` — so a provider error during *dissection* propagated raw and crashed the run (exactly what happened live).

## The fix (minimal, per the approved M1 plan §35)
- **Retry with exponential backoff + full jitter** for transient failures only: HTTP 429/500/502/503/504 + `URLError` (connection/timeout). `LlmConfig.max_retries=3`, `backoff_base_s=1.0` — both config, 0 disables.
- **Never retried:** 401 (`LlmAuthError`), 404/model-not-found, other 4xx — fail fast unchanged.
- **Symmetric isolation:** `land_silver` now catches `(DissectionError, LlmError)` → log + skip that one posting, run survives.

## Validation (behavioral + negative)
- 503,503,200 → succeeds with 2 backoffs · persistent 503 → `LlmError` after exactly `max_retries` (4 total attempts) · 401 → 1 attempt, no sleep · 422 → fail fast · URLError → retried · delay upper-bounds grow 1s,2s,4s · `max_retries=0` → single attempt
- `land_silver` with a dissector raising `LlmError` → posting skipped, no crash (was: run-fatal)
- 188 unit tests green, `ruff` clean

Part 1/3 of **M1 "pipeline hardening" (→ v0.2.0)**; next: H-2 concurrency + deadline guard, H-3 gold-filter precision. ERR-006 write-up lands in the M1 close-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable retry handling for AI requests, with exponential backoff for transient network, rate-limit, and server errors.
  * Added new settings to control retry count and backoff timing.

* **Bug Fixes**
  * Improved handling of request failures so authentication and invalid-model errors fail fast.
  * Prevented AI-related failures from crashing ingestion; affected items are now skipped cleanly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->