### PR TITLE
fix(gold): M1/H-3 — subset title matching + config-selectable filter strategy

### DIFF
--- a/src/jobfetcher/adapters/filter_deterministic.py
+++ b/src/jobfetcher/adapters/filter_deterministic.py
@@ -6,8 +6,12 @@ nothing the Scorer doesn't already do. A cheap rule-based filter cuts the obviou
 the Scorer does the fine judgment, so a borderline posting is kept, not dropped.
 
 Rule (likely-fit iff ALL hold):
-  1. **title** — token overlap between the posting title (normalized or raw) and the spec's
-     `job_titles` (the queried roles). Loose: a single shared meaningful token passes.
+  1. **title** — for SOME spec `job_title`, ALL of its meaningful tokens appear in the posting
+     title (normalized or raw): "Data Architect" needs `data` AND `architect`. (H-3: the old
+     any-single-shared-token rule passed *Azure Architect* / *Alliances Manager* for a
+     "Data Architect" spec — measured live; each junk pass costs a pro-model scoring call.
+     Semantic adjacency, e.g. "Analytics Architect", is deliberately NOT this filter's job —
+     that's the LlmFilterStrategy, selectable via $GOLD_FILTER_STRATEGY.)
   2. **location** — the posting's queried geo (`country`, then `city`) matches the spec's
      `targeting.countries` / `cities`. An empty target set means "no constraint" (matches all).
   3. **no dealbreaker** — none of `profile.preferences.avoid_keywords` appears in the title.
@@ -53,13 +57,14 @@ class DeterministicFilterStrategy:
 
     @staticmethod
     def _title_matches(spec: "SearchSpec", posting: "DissectedPosting") -> bool:
-        target = set()
-        for t in spec.targeting.job_titles:
-            target |= _tokens(t)
-        if not target:
+        # H-3 subset rule: SOME target title must have ALL its meaningful tokens present in
+        # the posting title. Titles that tokenize to nothing (all stopwords) can't constrain.
+        targets = [_tokens(t) for t in spec.targeting.job_titles]
+        targets = [t for t in targets if t]
+        if not targets:
             return True  # no targeting → don't constrain
         posting_tokens = _tokens(posting.normalized_title) | _tokens(posting.raw_title)
-        return bool(target & posting_tokens)
+        return any(target <= posting_tokens for target in targets)
 
     @staticmethod
     def _location_matches(spec: "SearchSpec", posting: "DissectedPosting") -> bool:

--- a/src/jobfetcher/handlers/pipeline.py
+++ b/src/jobfetcher/handlers/pipeline.py
@@ -72,6 +72,7 @@ _DB_SECRET_ARN_ENV = "DB_SECRET_ARN"
 _DB_NAME_ENV = "DB_NAME"
 _RECIPIENT_ENV = "RECIPIENT_EMAIL"
 _MAX_WORKERS_ENV = "PIPELINE_MAX_WORKERS"
+_GOLD_FILTER_ENV = "GOLD_FILTER_STRATEGY"
 
 # Seconds reserved before the Lambda's hard timeout: in-flight LLM calls + the tail of DB
 # writes + notify must finish inside this margin (H-2 deadline guard).
@@ -153,6 +154,23 @@ def resolve_deadline(context: Any) -> Deadline | None:
     return Deadline(get_remaining() / 1000.0 - _DEADLINE_MARGIN_S)
 
 
+def resolve_filter_strategy(env: dict[str, str]) -> Any:
+    """The gold `FilterStrategy` from `$GOLD_FILTER_STRATEGY` (H-3): `deterministic`
+    (default) or `llm` (the `LlmFilterStrategy` on the cheap dissect model — semantic
+    adjacency the token rule can't judge). Raises `ValueError` on anything else — a
+    misconfigured stage must fail loudly, never silently fall back."""
+    choice = (env.get(_GOLD_FILTER_ENV) or "deterministic").strip().lower()
+    if choice == "deterministic":
+        return DeterministicFilterStrategy()
+    if choice == "llm":
+        from ..adapters.filter_llm import LlmFilterStrategy
+
+        return LlmFilterStrategy(OpenAICompatLlmClient(LlmConfig(model=_DISSECT_MODEL)))
+    raise ValueError(
+        f"${_GOLD_FILTER_ENV} must be 'deterministic' or 'llm', got {choice!r}"
+    )
+
+
 # --------------------------------------------------------------------------- handler
 def handler(event: dict[str, Any] | None = None, context: Any = None) -> dict[str, Any]:
     """The one v0 Lambda. Returns a `{statusCode, run_id, ...stage counts}` summary.
@@ -201,7 +219,7 @@ def handler(event: dict[str, Any] | None = None, context: Any = None) -> dict[st
         dissector = Dissector(
             OpenAICompatLlmClient(LlmConfig(model=_DISSECT_MODEL)), model_id=_DISSECT_MODEL
         )
-        strategy = DeterministicFilterStrategy()
+        strategy = resolve_filter_strategy(env)  # H-3: deterministic (default) | llm
         scorer = Scorer(
             OpenAICompatLlmClient(LlmConfig(model=_SCORE_MODEL)), model_id=_SCORE_MODEL
         )

--- a/tests/test_gold_filter.py
+++ b/tests/test_gold_filter.py
@@ -97,6 +97,68 @@ def test_deterministic_empty_targeting_is_permissive():
     assert DeterministicFilterStrategy().filter(_spec(cities=[]), _profile(), _posting()) is True
 
 
+# ------------------------------------------------------------- H-3: subset title matching
+# The six REAL junk titles the live P2 run (2026-07-02) passed to the pro-model scorer under
+# the old any-single-shared-token rule, querying "Data Architect" — every one scored ≤15.
+_LIVE_JUNK_TITLES = [
+    "Analytics Architect",
+    "Enterprise Architect",
+    "Arangodb Architect",
+    "Alliances Manager - Data & AI",
+    "Computer Vision Engineer",
+    "Azure Architect",
+]
+
+
+@pytest.mark.parametrize("junk_title", _LIVE_JUNK_TITLES)
+def test_h3_live_junk_titles_are_rejected(junk_title):
+    """H-3 negative (the measured live failure): none of the junk that a 'Data Architect'
+    query passed through the old single-token rule may pass the subset rule."""
+    spec = _spec(titles=["Data Architect"], countries=["om"])
+    junk = _posting(title=junk_title, country="om", city="Muscat", location="Muscat")
+    assert DeterministicFilterStrategy().filter(spec, _profile(), junk) is False
+
+
+@pytest.mark.parametrize(
+    ("spec_title", "posting_title"),
+    [
+        ("Data Architect", "Data Architect"),
+        ("Data Architect", "Senior Data Architect"),  # seniority tokens are stopworded
+        ("Data Architect", "Lead Data Solutions Architect (Cloud)"),  # extra tokens fine
+        ("Data Engineer", "Lead Data Engineer"),
+        ("Data Platform Engineer", "Senior Data Platform Engineer"),
+    ],
+)
+def test_h3_target_variants_still_pass(spec_title, posting_title):
+    """H-3 positive: real variants of the target titles (seniority prefixes, extra tokens)
+    must keep passing — the subset rule requires the target's tokens, not an exact string."""
+    spec = _spec(titles=[spec_title])
+    posting = _posting(title=posting_title)
+    assert DeterministicFilterStrategy().filter(spec, _profile(), posting) is True
+
+
+def test_h3_any_of_multiple_targets_suffices():
+    # a "Data Engineer" posting passes a spec targeting engineer+architect (ANY target)
+    spec = _spec(titles=["Data Architect", "Data Engineer"])
+    posting = _posting(title="Data Engineer")
+    assert DeterministicFilterStrategy().filter(spec, _profile(), posting) is True
+
+
+def test_h3_partial_target_overlap_is_rejected():
+    # negative: sharing ONE token of the target ("architect" but not "data") no longer passes
+    spec = _spec(titles=["Data Architect"])
+    posting = _posting(title="Software Architect")
+    assert DeterministicFilterStrategy().filter(spec, _profile(), posting) is False
+
+
+def test_h3_normalized_and_raw_titles_are_pooled():
+    # tokens may come from either title field — raw says "Sr. DE", normalized carries the rest
+    spec = _spec(titles=["Data Engineer"])
+    posting = _posting(title="Sr. Data Wrangler")
+    posting = posting.model_copy(update={"normalized_title": "Data Engineer"})
+    assert DeterministicFilterStrategy().filter(spec, _profile(), posting) is True
+
+
 # --------------------------------------------------------------------------- LLM strategy
 def test_llm_filter_true():
     llm = FakeLlm(json.dumps({"likely_fit": True, "reason": "matches role"}))

--- a/tests/test_handler_helpers.py
+++ b/tests/test_handler_helpers.py
@@ -154,3 +154,28 @@ def test_resolve_deadline_none_without_real_context():
     # local runs / tests pass None (or an object without the Lambda method) → no time budget
     assert resolve_deadline(None) is None
     assert resolve_deadline(object()) is None
+
+
+# --------------------------------------------------------------------------- H-3 gold filter
+def test_resolve_filter_strategy_default_and_explicit(monkeypatch):
+    from jobfetcher.adapters.filter_deterministic import DeterministicFilterStrategy
+    from jobfetcher.adapters.filter_llm import LlmFilterStrategy
+    from jobfetcher.handlers.pipeline import resolve_filter_strategy
+
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "test-key")  # llm path builds a client (no call)
+    assert isinstance(resolve_filter_strategy({}), DeterministicFilterStrategy)
+    assert isinstance(
+        resolve_filter_strategy({"GOLD_FILTER_STRATEGY": "deterministic"}),
+        DeterministicFilterStrategy,
+    )
+    assert isinstance(
+        resolve_filter_strategy({"GOLD_FILTER_STRATEGY": "LLM"}), LlmFilterStrategy
+    )
+
+
+def test_resolve_filter_strategy_rejects_junk():
+    # negative: a typo'd strategy must fail loudly, never silently fall back to a default
+    from jobfetcher.handlers.pipeline import resolve_filter_strategy
+
+    with pytest.raises(ValueError, match="GOLD_FILTER_STRATEGY"):
+        resolve_filter_strategy({"GOLD_FILTER_STRATEGY": "fuzzy"})


### PR DESCRIPTION
> **Stacked on #15 (H-2)** — merge order: #14 → #15 → this. GitHub re-targets automatically as each base merges.

## The bottleneck (measured live, P2 run 2026-07-02)
The gold filter's title rule passed on **any one shared token** — a "Data Architect" spec sent *Azure Architect, Enterprise Architect, ArangoDB Architect, Alliances Manager, Computer Vision Engineer* to the expensive pro-model scorer. All scored ≤15: the scorer was doing the filter's job, one paid call at a time.

## The fix (per the approved M1 plan §35)
- **Subset title rule:** for SOME spec title, ALL its meaningful tokens must appear in the posting title (normalized ∪ raw). "Data Architect" → needs `data` AND `architect`. Seniority words stay stopworded, extra tokens are fine, empty targeting stays unconstrained.
- **Semantic adjacency** ("Analytics Architect") is deliberately NOT this filter's judgment — that's the already-built `LlmFilterStrategy`, which this PR finally makes selectable: **`$GOLD_FILTER_STRATEGY` = `deterministic` (default) | `llm`** (fail-open in `apply_gold_filter`, flash model). Junk value → loud `ValueError`.

## Validation (behavioral + negative)
- The **six real junk titles from the live run** are committed as rejected fixtures
- Variants still pass: `Senior Data Architect`, `Lead Data Solutions Architect (Cloud)`, `Lead Data Engineer`, `Senior Data Platform Engineer` · multi-target ANY works · single-token overlap (`Software Architect`) rejected · raw+normalized pooling proven
- `resolve_filter_strategy`: default/explicit/case-insensitive + junk → `ValueError`
- 212 unit tests green · `ruff` clean

Part 3/3 of **M1 "pipeline hardening" (→ v0.2.0)**. After all three merge: rebuild + apply + live re-validation on the sweep backlog, then the ADR-0021/ledger close-out and the v0.2.0 tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)