### PR TITLE
fix(pipeline): land M1 H-2+H-3 on main (stacked-PR base mishap)

### DIFF
--- a/src/jobfetcher/adapters/filter_deterministic.py
+++ b/src/jobfetcher/adapters/filter_deterministic.py
@@ -6,8 +6,12 @@ nothing the Scorer doesn't already do. A cheap rule-based filter cuts the obviou
 the Scorer does the fine judgment, so a borderline posting is kept, not dropped.
 
 Rule (likely-fit iff ALL hold):
-  1. **title** — token overlap between the posting title (normalized or raw) and the spec's
-     `job_titles` (the queried roles). Loose: a single shared meaningful token passes.
+  1. **title** — for SOME spec `job_title`, ALL of its meaningful tokens appear in the posting
+     title (normalized or raw): "Data Architect" needs `data` AND `architect`. (H-3: the old
+     any-single-shared-token rule passed *Azure Architect* / *Alliances Manager* for a
+     "Data Architect" spec — measured live; each junk pass costs a pro-model scoring call.
+     Semantic adjacency, e.g. "Analytics Architect", is deliberately NOT this filter's job —
+     that's the LlmFilterStrategy, selectable via $GOLD_FILTER_STRATEGY.)
   2. **location** — the posting's queried geo (`country`, then `city`) matches the spec's
      `targeting.countries` / `cities`. An empty target set means "no constraint" (matches all).
   3. **no dealbreaker** — none of `profile.preferences.avoid_keywords` appears in the title.
@@ -53,13 +57,14 @@ class DeterministicFilterStrategy:
 
     @staticmethod
     def _title_matches(spec: "SearchSpec", posting: "DissectedPosting") -> bool:
-        target = set()
-        for t in spec.targeting.job_titles:
-            target |= _tokens(t)
-        if not target:
+        # H-3 subset rule: SOME target title must have ALL its meaningful tokens present in
+        # the posting title. Titles that tokenize to nothing (all stopwords) can't constrain.
+        targets = [_tokens(t) for t in spec.targeting.job_titles]
+        targets = [t for t in targets if t]
+        if not targets:
             return True  # no targeting → don't constrain
         posting_tokens = _tokens(posting.normalized_title) | _tokens(posting.raw_title)
-        return bool(target & posting_tokens)
+        return any(target <= posting_tokens for target in targets)
 
     @staticmethod
     def _location_matches(spec: "SearchSpec", posting: "DissectedPosting") -> bool:

--- a/src/jobfetcher/adapters/llm_openai.py
+++ b/src/jobfetcher/adapters/llm_openai.py
@@ -17,6 +17,7 @@ import json
 import logging
 import os
 import random
+import threading
 import time
 import urllib.error
 import urllib.request
@@ -60,10 +61,13 @@ class OpenAICompatLlmClient:
     def __init__(self, config: LlmConfig | None = None, *, api_key: str | None = None) -> None:
         self.config = config or LlmConfig()
         self._api_key = api_key  # resolved lazily on first call
+        self._key_lock = threading.Lock()  # H-2: first call may race across worker threads
 
     def _key(self) -> str:
         if not self._api_key:
-            self._api_key = _resolve_api_key(self.config)
+            with self._key_lock:
+                if not self._api_key:  # double-check under the lock
+                    self._api_key = _resolve_api_key(self.config)
         if not self._api_key:
             raise LlmAuthError(
                 f"no API key found (env ${_ENV_KEY} or Secrets Manager '{self.config.secret_name}')"

--- a/src/jobfetcher/core/ingest.py
+++ b/src/jobfetcher/core/ingest.py
@@ -10,6 +10,8 @@ failure skips one posting without losing the raw or crashing the run.
 from __future__ import annotations
 
 import logging
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import date
 from typing import TYPE_CHECKING, Any
 
@@ -40,6 +42,27 @@ _DEFAULT_HARD_FLOOR = 50
 _DEFAULT_NEAR_MISS_BAND = 10
 
 log = logging.getLogger(__name__)
+
+# LLM calls are pure I/O — this many run concurrently per stage (H-2). DB writes always stay
+# on the main thread (the Data-API dialect's thread-safety is deliberately not relied on).
+DEFAULT_MAX_WORKERS = 8
+
+# Sentinel returned by a worker whose task started after the deadline: the item was neither
+# processed nor failed — it is deferred to the next (idempotent) run.
+_DEFERRED = object()
+
+
+class Deadline:
+    """A wall-clock budget for LLM work (H-2). Workers check `expired` before starting an
+    LLM call; past the deadline, remaining items are *deferred* (counted, not lost) and the
+    run returns partial-but-clean instead of being killed by the Lambda timeout."""
+
+    def __init__(self, seconds: float) -> None:
+        self._until = time.monotonic() + max(seconds, 0.0)
+
+    @property
+    def expired(self) -> bool:
+        return time.monotonic() >= self._until
 
 
 def fetch_to_bronze(
@@ -111,6 +134,38 @@ def land_silver(
     `language` (from `spec.language`) is recorded on the posting metadata — never hardcoded.
     `query_country` (the country actually queried) is the authoritative geo scope (C3): it
     overrides the unreliable per-record `job_country` when set."""
+    prepared = _prepare_silver(
+        bronze_id,
+        raw_payload,
+        run_id=run_id,
+        source=source,
+        source_job_id=source_job_id,
+        dissector=dissector,
+        language=language,
+        query_country=query_country,
+        pipeline_version=pipeline_version,
+    )
+    if prepared is None:
+        return None
+    dissected, kwargs = prepared
+    return repo.save_posting(dissected, **kwargs)
+
+
+def _prepare_silver(
+    bronze_id: str,
+    raw_payload: dict[str, Any],
+    *,
+    run_id: str,
+    source: str,
+    source_job_id: str,
+    dissector: "Dissector",
+    language: str = "en",
+    query_country: str | None = None,
+    pipeline_version: str = "v0",
+) -> tuple[Any, dict[str, Any]] | None:
+    """The pure-LLM half of `land_silver` — map → clean → fingerprint → dissect, **no DB**
+    (H-2: this is what runs on the worker threads). Returns `(dissected, save_kwargs)` for
+    the main-thread `repo.save_posting`, or `None` on an isolated dissection failure."""
     jd_text, meta = jd_and_metadata_from_jsearch(
         raw_payload, language=language, query_country=query_country
     )
@@ -133,21 +188,20 @@ def land_silver(
     except (DissectionError, LlmError) as exc:
         log.warning("dissection failed for %s (run_id=%s): %s", bronze_id, run_id, exc)
         return None
-    return repo.save_posting(
-        dissected,
-        posting_id=f"{source}:{source_job_id}",
-        bronze_id=bronze_id,
-        source=source,
-        source_job_id=source_job_id,
-        run_id=run_id,
-        company=raw_payload.get("employer_name"),
-        apply_url=raw_payload.get("job_apply_link"),
-        description=raw_payload.get("job_description"),
-        state=raw_payload.get("job_state"),
-        pipeline_version=pipeline_version,
-        fingerprint=fp,
-        status="silver",
-    )
+    return dissected, {
+        "posting_id": f"{source}:{source_job_id}",
+        "bronze_id": bronze_id,
+        "source": source,
+        "source_job_id": source_job_id,
+        "run_id": run_id,
+        "company": raw_payload.get("employer_name"),
+        "apply_url": raw_payload.get("job_apply_link"),
+        "description": raw_payload.get("job_description"),
+        "state": raw_payload.get("job_state"),
+        "pipeline_version": pipeline_version,
+        "fingerprint": fp,
+        "status": "silver",
+    }
 
 
 def ingest(
@@ -160,11 +214,19 @@ def ingest(
     dissector: "Dissector",
     source: str = "jsearch",
     pipeline_version: str = "v0",
+    max_workers: int = DEFAULT_MAX_WORKERS,
+    deadline: Deadline | None = None,
 ) -> dict[str, int]:
     """End-to-end Step-4 run: fetch→bronze, then derive silver for each *distinct, new*
     posting. Returns a small summary of counts. `bronzed` == distinct ids landed this run;
-    `silvered` + `skipped` + `already` partition them: `skipped` = dissection failures,
-    `already` = an existing posting we did NOT re-dissect (C2: a re-run wastes no LLM call)."""
+    `silvered` + `skipped` + `already` + `deferred` partition them: `skipped` = dissection
+    failures, `already` = an existing posting we did NOT re-dissect (C2: a re-run wastes no
+    LLM call), `deferred` = not attempted because the `deadline` passed (the next idempotent
+    run picks them up).
+
+    **Concurrency model (H-2):** dissections (pure LLM I/O) run on up to `max_workers`
+    threads; every `repo` write stays on the main thread — the Data-API dialect's
+    thread-safety is never relied on."""
     landed = fetch_to_bronze(
         spec,
         run_id=run_id,
@@ -176,29 +238,54 @@ def ingest(
     silvered = 0
     skipped = 0
     already = 0
+    deferred = 0
+
+    # Main-thread pass: partition into already-silvered vs to-dissect (repo reads stay here).
+    work: list[tuple[str, dict[str, Any], str | None]] = []
     for bronze_id, raw, query_country in landed:
         posting_id = f"{source}:{raw['job_id']}"
         # C2: a posting that already exists must NOT be re-dissected — that is wasted LLM cost
         # on a re-run. Skip the silver/LLM pass entirely and count it.
         if repo.get_posting(posting_id) is not None:
             already += 1
-            continue
-        result = land_silver(
+        else:
+            work.append((bronze_id, raw, query_country))
+
+    def _dissect_task(item: tuple[str, dict[str, Any], str | None]):
+        if deadline is not None and deadline.expired:
+            return _DEFERRED  # out of time budget — leave for the next run, don't start LLM work
+        bronze_id, raw, query_country = item
+        return _prepare_silver(
             bronze_id,
             raw,
             run_id=run_id,
             source=source,
             source_job_id=raw["job_id"],
             dissector=dissector,
-            repo=repo,
             language=spec.language,
             query_country=query_country,
             pipeline_version=pipeline_version,
         )
-        if result is None:
-            skipped += 1
-        else:
-            silvered += 1
+
+    if work:
+        with ThreadPoolExecutor(max_workers=max_workers) as pool:
+            futures = [pool.submit(_dissect_task, item) for item in work]
+            for fut in as_completed(futures):
+                outcome = fut.result()
+                if outcome is _DEFERRED:
+                    deferred += 1
+                elif outcome is None:
+                    skipped += 1
+                else:
+                    dissected, kwargs = outcome
+                    repo.save_posting(dissected, **kwargs)  # main thread — the only writer
+                    silvered += 1
+    if deferred:
+        log.warning(
+            "ingest deadline reached (run_id=%s): %d dissection(s) deferred to the next run",
+            run_id,
+            deferred,
+        )
 
     return {
         "fetched": len(landed),
@@ -206,6 +293,7 @@ def ingest(
         "silvered": silvered,
         "skipped": skipped,
         "already": already,
+        "deferred": deferred,
     }
 
 
@@ -291,6 +379,8 @@ def score_gold(
     repo: "Repository",
     scorer: "Scorer",
     user_id: str = DEFAULT_USER_ID,
+    max_workers: int = DEFAULT_MAX_WORKERS,
+    deadline: Deadline | None = None,
 ) -> dict[str, int]:
     """Step-5 scoring: load the candidate profile + its **runtime** threshold knobs, then for
     each gold candidate -> score it (LLM) -> derive its `fit_category` from the config bands
@@ -305,8 +395,13 @@ def score_gold(
     run** (mirrors `land_silver`): one un-scorable posting must not lose the rest of the
     shortlist — but a DB failure (`RepositoryError`) stays loud and aborts the run.
 
-    Returns `{gold, scored, surfaced, failed}` — `gold` = candidates examined; `scored` +
-    `failed` partition them; `surfaced` = those at/above the threshold (a subset of `scored`).
+    Returns `{gold, scored, surfaced, failed, deferred}` — `gold` = candidates examined;
+    `scored` + `failed` + `deferred` partition them; `surfaced` = those at/above the
+    threshold (a subset of `scored`); `deferred` = not attempted (deadline passed — the next
+    idempotent run scores them).
+
+    **Concurrency model (H-2):** scoring calls (pure LLM I/O) run on up to `max_workers`
+    threads; the `save_score`/`mark_scored` writes stay on the main thread.
     """
     row = repo.get_profile(user_id)
     if row is None:
@@ -324,36 +419,64 @@ def score_gold(
     scored = 0
     surfaced = 0
     failed = 0
-    for posting_id, cluster_id, dissected in candidates:
+    deferred = 0
+
+    def _score_task(candidate: tuple) -> Any:
+        posting_id, _cluster_id, dissected = candidate
+        if deadline is not None and deadline.expired:
+            return _DEFERRED  # out of time budget — leave for the next run
         try:
-            result = scorer.score(dissected, profile)
+            return scorer.score(dissected, profile)
         except (ScorerError, LlmError) as exc:
             log.warning("scoring failed for %s (run_id=%s): %s", posting_id, run_id, exc)
-            failed += 1
-            continue
+            return None
 
-        fit_category = derive_fit_category(
-            result.score,
-            threshold=threshold,
-            hard_floor=hard_floor,
-            near_miss_band=near_miss_band,
+    if candidates:
+        with ThreadPoolExecutor(max_workers=max_workers) as pool:
+            futures = {pool.submit(_score_task, c): c for c in candidates}
+            for fut in as_completed(futures):
+                result = fut.result()
+                if result is _DEFERRED:
+                    deferred += 1
+                    continue
+                if result is None:
+                    failed += 1
+                    continue
+                posting_id, cluster_id, _dissected = futures[fut]
+                fit_category = derive_fit_category(
+                    result.score,
+                    threshold=threshold,
+                    hard_floor=hard_floor,
+                    near_miss_band=near_miss_band,
+                )
+                repo.save_score(  # main thread — the only writer
+                    cluster_id=cluster_id,
+                    score=result.score,
+                    fit_category=fit_category,
+                    strengths=result.strengths,
+                    gaps=result.gaps,
+                    strategic_assessment=result.strategic_assessment,
+                    poster_type=result.poster_type,
+                    legitimacy_verified=result.legitimacy_verified,
+                )
+                repo.mark_scored(posting_id)
+                scored += 1
+                if result.score >= threshold:
+                    surfaced += 1
+    if deferred:
+        log.warning(
+            "scoring deadline reached (run_id=%s): %d candidate(s) deferred to the next run",
+            run_id,
+            deferred,
         )
-        repo.save_score(
-            cluster_id=cluster_id,
-            score=result.score,
-            fit_category=fit_category,
-            strengths=result.strengths,
-            gaps=result.gaps,
-            strategic_assessment=result.strategic_assessment,
-            poster_type=result.poster_type,
-            legitimacy_verified=result.legitimacy_verified,
-        )
-        repo.mark_scored(posting_id)
-        scored += 1
-        if result.score >= threshold:
-            surfaced += 1
 
-    return {"gold": len(candidates), "scored": scored, "surfaced": surfaced, "failed": failed}
+    return {
+        "gold": len(candidates),
+        "scored": scored,
+        "surfaced": surfaced,
+        "failed": failed,
+        "deferred": deferred,
+    }
 
 
 def notify(

--- a/src/jobfetcher/handlers/pipeline.py
+++ b/src/jobfetcher/handlers/pipeline.py
@@ -72,6 +72,7 @@ _DB_SECRET_ARN_ENV = "DB_SECRET_ARN"
 _DB_NAME_ENV = "DB_NAME"
 _RECIPIENT_ENV = "RECIPIENT_EMAIL"
 _MAX_WORKERS_ENV = "PIPELINE_MAX_WORKERS"
+_GOLD_FILTER_ENV = "GOLD_FILTER_STRATEGY"
 
 # Seconds reserved before the Lambda's hard timeout: in-flight LLM calls + the tail of DB
 # writes + notify must finish inside this margin (H-2 deadline guard).
@@ -153,6 +154,23 @@ def resolve_deadline(context: Any) -> Deadline | None:
     return Deadline(get_remaining() / 1000.0 - _DEADLINE_MARGIN_S)
 
 
+def resolve_filter_strategy(env: dict[str, str]) -> Any:
+    """The gold `FilterStrategy` from `$GOLD_FILTER_STRATEGY` (H-3): `deterministic`
+    (default) or `llm` (the `LlmFilterStrategy` on the cheap dissect model — semantic
+    adjacency the token rule can't judge). Raises `ValueError` on anything else — a
+    misconfigured stage must fail loudly, never silently fall back."""
+    choice = (env.get(_GOLD_FILTER_ENV) or "deterministic").strip().lower()
+    if choice == "deterministic":
+        return DeterministicFilterStrategy()
+    if choice == "llm":
+        from ..adapters.filter_llm import LlmFilterStrategy
+
+        return LlmFilterStrategy(OpenAICompatLlmClient(LlmConfig(model=_DISSECT_MODEL)))
+    raise ValueError(
+        f"${_GOLD_FILTER_ENV} must be 'deterministic' or 'llm', got {choice!r}"
+    )
+
+
 # --------------------------------------------------------------------------- handler
 def handler(event: dict[str, Any] | None = None, context: Any = None) -> dict[str, Any]:
     """The one v0 Lambda. Returns a `{statusCode, run_id, ...stage counts}` summary.
@@ -201,7 +219,7 @@ def handler(event: dict[str, Any] | None = None, context: Any = None) -> dict[st
         dissector = Dissector(
             OpenAICompatLlmClient(LlmConfig(model=_DISSECT_MODEL)), model_id=_DISSECT_MODEL
         )
-        strategy = DeterministicFilterStrategy()
+        strategy = resolve_filter_strategy(env)  # H-3: deterministic (default) | llm
         scorer = Scorer(
             OpenAICompatLlmClient(LlmConfig(model=_SCORE_MODEL)), model_id=_SCORE_MODEL
         )

--- a/src/jobfetcher/handlers/pipeline.py
+++ b/src/jobfetcher/handlers/pipeline.py
@@ -38,10 +38,12 @@ from ..adapters.ses_notifier import SesNotifier
 from ..config import LlmConfig
 from ..core.dissector import Dissector
 from ..core.ingest import (
+    DEFAULT_MAX_WORKERS,
     DEFAULT_USER_ID,
     _DEFAULT_HARD_FLOOR,
     _DEFAULT_NEAR_MISS_BAND,
     _DEFAULT_THRESHOLD,
+    Deadline,
     apply_gold_filter,
     ingest,
     notify,
@@ -69,6 +71,11 @@ _DB_CLUSTER_ARN_ENV = "DB_CLUSTER_ARN"
 _DB_SECRET_ARN_ENV = "DB_SECRET_ARN"
 _DB_NAME_ENV = "DB_NAME"
 _RECIPIENT_ENV = "RECIPIENT_EMAIL"
+_MAX_WORKERS_ENV = "PIPELINE_MAX_WORKERS"
+
+# Seconds reserved before the Lambda's hard timeout: in-flight LLM calls + the tail of DB
+# writes + notify must finish inside this margin (H-2 deadline guard).
+_DEADLINE_MARGIN_S = 60.0
 
 
 # --------------------------------------------------------------------------- pure helpers
@@ -124,13 +131,40 @@ def resolve_profile_path(env: dict[str, str]) -> str:
     return env.get(_PROFILE_ENV) or _DEFAULT_PROFILE_PATH
 
 
+def resolve_max_workers(env: dict[str, str]) -> int:
+    """`$PIPELINE_MAX_WORKERS` (H-2 concurrency knob) or the documented default. Pure.
+    Raises `ValueError` on a non-integer or a value < 1 — a clear misconfig, never a
+    silent fallback."""
+    raw = (env.get(_MAX_WORKERS_ENV) or "").strip()
+    if not raw:
+        return DEFAULT_MAX_WORKERS
+    workers = int(raw)  # ValueError on junk, deliberately
+    if workers < 1:
+        raise ValueError(f"${_MAX_WORKERS_ENV} must be >= 1, got {workers}")
+    return workers
+
+
+def resolve_deadline(context: Any) -> Deadline | None:
+    """A `Deadline` from the Lambda context's remaining time minus a safety margin (H-2),
+    or `None` when there is no real context (local runs / tests → no time budget). Pure."""
+    get_remaining = getattr(context, "get_remaining_time_in_millis", None)
+    if not callable(get_remaining):
+        return None
+    return Deadline(get_remaining() / 1000.0 - _DEADLINE_MARGIN_S)
+
+
 # --------------------------------------------------------------------------- handler
-def handler(event: dict[str, Any] | None = None, context: Any = None) -> dict[str, Any]:  # noqa: ARG001
+def handler(event: dict[str, Any] | None = None, context: Any = None) -> dict[str, Any]:
     """The one v0 Lambda. Returns a `{statusCode, run_id, ...stage counts}` summary.
 
     On any stage failure: log it with `run_id`, return `{statusCode: 500, ...}` so the run is
     retried (and resumes — upserts skip done work, `run_log` blocks a double email). On success:
     `{statusCode: 200, ...}` with the per-stage counts.
+
+    **Deadline guard (H-2):** LLM stages stop *starting* new work `_DEADLINE_MARGIN_S` before
+    the Lambda timeout and report the remainder as `deferred`; the summary then carries
+    `partial: true` and **notify is skipped** — the digest goes out on the completing re-run
+    (sending early would trip the send-once `run_log` guard with an incomplete shortlist).
     """
     event = event or {}
     run_id = resolve_run_id(event)
@@ -143,6 +177,8 @@ def handler(event: dict[str, Any] | None = None, context: Any = None) -> dict[st
         spec = SearchSpec.from_yaml(resolve_search_config_path(env))
         profile = Profile.from_yaml(resolve_profile_path(env))
         recipient = (env.get(_RECIPIENT_ENV) or "").strip()
+        max_workers = resolve_max_workers(env)
+        deadline = resolve_deadline(context)
 
         repo = PostgresRepository(resolve_db_url(env))
 
@@ -181,6 +217,8 @@ def handler(event: dict[str, Any] | None = None, context: Any = None) -> dict[st
             repo=repo,
             dissector=dissector,
             source=spec.source,
+            max_workers=max_workers,
+            deadline=deadline,
         )
         rlog.info("stage=ingest done %s", ingest_counts)
 
@@ -192,13 +230,31 @@ def handler(event: dict[str, Any] | None = None, context: Any = None) -> dict[st
         rlog.info("stage=gold done %s", gold_counts)
 
         rlog.info("stage=score start")
-        score_counts = score_gold(run_id=run_id, repo=repo, scorer=scorer, user_id=user_id)
+        score_counts = score_gold(
+            run_id=run_id,
+            repo=repo,
+            scorer=scorer,
+            user_id=user_id,
+            max_workers=max_workers,
+            deadline=deadline,
+        )
         rlog.info("stage=score done %s", score_counts)
 
-        # --- notify: send-once guard (VG4). Skip entirely if the digest already went out today.
-        if repo.was_digest_sent(user_id=user_id, run_date=run_date):
-            rlog.info("stage=notify skipped — digest already sent for %s", run_date.isoformat())
+        # --- notify: send-once guard (VG4). Skip entirely if the digest already went out today,
+        # or if this run is PARTIAL (deadline deferred work) — an early digest would trip the
+        # send-once guard with an incomplete shortlist; the completing re-run sends it.
+        partial = bool(ingest_counts.get("deferred") or score_counts.get("deferred"))
+        if partial:
+            rlog.warning(
+                "stage=notify skipped — partial run (deferred: ingest=%s score=%s); "
+                "the completing re-run sends the digest",
+                ingest_counts.get("deferred", 0),
+                score_counts.get("deferred", 0),
+            )
             notify_counts: dict[str, int] = {"surfaced": 0, "below_threshold": 0, "sent": 0}
+        elif repo.was_digest_sent(user_id=user_id, run_date=run_date):
+            rlog.info("stage=notify skipped — digest already sent for %s", run_date.isoformat())
+            notify_counts = {"surfaced": 0, "below_threshold": 0, "sent": 0}
         else:
             rlog.info("stage=notify start recipient=%s", recipient)
             notify_counts = notify(
@@ -227,6 +283,7 @@ def handler(event: dict[str, Any] | None = None, context: Any = None) -> dict[st
         "statusCode": 200,
         "run_id": run_id,
         "run_date": run_date.isoformat(),
+        "partial": partial,
         "ingest": ingest_counts,
         "gold": gold_counts,
         "score": score_counts,

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -33,9 +33,11 @@ resource "aws_lambda_function" "pipeline" {
   filename         = data.archive_file.lambda.output_path
   source_code_hash = data.archive_file.lambda.output_base64sha256
 
-  timeout     = 900 # 15 min (max) — each posting is an LLM dissect/score + a Data-API write
+  timeout = 900 # 15 min (max) — each posting is an LLM dissect/score + a Data-API write
   # (~30s over the network), so the daily batch needs real headroom (vs the Aurora cold-resume too).
-  memory_size = 512
+  # H-2: dissect/score run up to $PIPELINE_MAX_WORKERS (default 8) concurrent LLM calls, and the
+  # handler's deadline guard stops new work ~60s before this timeout (partial runs resume).
+  memory_size = 1024 # Lambda CPU scales with memory — 8 worker threads + TLS need the headroom
 
   # Config only — NO secret VALUES. The handler fetches secret values at runtime
   # via the Data API / Secrets Manager using the names/ARNs below; config files are
@@ -45,15 +47,24 @@ resource "aws_lambda_function" "pipeline" {
       ENV = var.env
       # The env-var name the S3RawStore adapter actually reads (s3_raw.py: $JOBFETCHER_DATA_BUCKET).
       JOBFETCHER_DATA_BUCKET = aws_s3_bucket.data.id
-      DB_CLUSTER_ARN       = aws_rds_cluster.main.arn
-      DB_SECRET_ARN        = aws_rds_cluster.main.master_user_secret[0].secret_arn
-      DB_NAME              = var.db_name
-      DEEPSEEK_SECRET_NAME = var.deepseek_secret_name
-      JSEARCH_SECRET_NAME  = var.jsearch_secret_name
-      SES_SENDER           = var.sender_email
-      RECIPIENT_EMAIL      = var.recipient_email
-      SEARCH_CONFIG_PATH   = var.search_config_path
-      PROFILE_PATH         = var.profile_path
+      DB_CLUSTER_ARN         = aws_rds_cluster.main.arn
+      DB_SECRET_ARN          = aws_rds_cluster.main.master_user_secret[0].secret_arn
+      DB_NAME                = var.db_name
+      DEEPSEEK_SECRET_NAME   = var.deepseek_secret_name
+      JSEARCH_SECRET_NAME    = var.jsearch_secret_name
+      SES_SENDER             = var.sender_email
+      RECIPIENT_EMAIL        = var.recipient_email
+      SEARCH_CONFIG_PATH     = var.search_config_path
+      PROFILE_PATH           = var.profile_path
     }
   }
+}
+
+# H-2 / ERR-007: a timed-out async invoke must NEVER be blind-retried by AWS — the live P2 run
+# showed the default (2 retries) re-fetching the whole sweep after a timeout, burning JSearch
+# quota + LLM tokens on a run that would only time out again. Retries are the pipeline's own
+# job (idempotent resume via EventBridge tomorrow / a manual re-invoke), not the platform's.
+resource "aws_lambda_function_event_invoke_config" "pipeline" {
+  function_name          = aws_lambda_function.pipeline.function_name
+  maximum_retry_attempts = 0
 }

--- a/tests/test_gold_filter.py
+++ b/tests/test_gold_filter.py
@@ -97,6 +97,68 @@ def test_deterministic_empty_targeting_is_permissive():
     assert DeterministicFilterStrategy().filter(_spec(cities=[]), _profile(), _posting()) is True
 
 
+# ------------------------------------------------------------- H-3: subset title matching
+# The six REAL junk titles the live P2 run (2026-07-02) passed to the pro-model scorer under
+# the old any-single-shared-token rule, querying "Data Architect" — every one scored ≤15.
+_LIVE_JUNK_TITLES = [
+    "Analytics Architect",
+    "Enterprise Architect",
+    "Arangodb Architect",
+    "Alliances Manager - Data & AI",
+    "Computer Vision Engineer",
+    "Azure Architect",
+]
+
+
+@pytest.mark.parametrize("junk_title", _LIVE_JUNK_TITLES)
+def test_h3_live_junk_titles_are_rejected(junk_title):
+    """H-3 negative (the measured live failure): none of the junk that a 'Data Architect'
+    query passed through the old single-token rule may pass the subset rule."""
+    spec = _spec(titles=["Data Architect"], countries=["om"])
+    junk = _posting(title=junk_title, country="om", city="Muscat", location="Muscat")
+    assert DeterministicFilterStrategy().filter(spec, _profile(), junk) is False
+
+
+@pytest.mark.parametrize(
+    ("spec_title", "posting_title"),
+    [
+        ("Data Architect", "Data Architect"),
+        ("Data Architect", "Senior Data Architect"),  # seniority tokens are stopworded
+        ("Data Architect", "Lead Data Solutions Architect (Cloud)"),  # extra tokens fine
+        ("Data Engineer", "Lead Data Engineer"),
+        ("Data Platform Engineer", "Senior Data Platform Engineer"),
+    ],
+)
+def test_h3_target_variants_still_pass(spec_title, posting_title):
+    """H-3 positive: real variants of the target titles (seniority prefixes, extra tokens)
+    must keep passing — the subset rule requires the target's tokens, not an exact string."""
+    spec = _spec(titles=[spec_title])
+    posting = _posting(title=posting_title)
+    assert DeterministicFilterStrategy().filter(spec, _profile(), posting) is True
+
+
+def test_h3_any_of_multiple_targets_suffices():
+    # a "Data Engineer" posting passes a spec targeting engineer+architect (ANY target)
+    spec = _spec(titles=["Data Architect", "Data Engineer"])
+    posting = _posting(title="Data Engineer")
+    assert DeterministicFilterStrategy().filter(spec, _profile(), posting) is True
+
+
+def test_h3_partial_target_overlap_is_rejected():
+    # negative: sharing ONE token of the target ("architect" but not "data") no longer passes
+    spec = _spec(titles=["Data Architect"])
+    posting = _posting(title="Software Architect")
+    assert DeterministicFilterStrategy().filter(spec, _profile(), posting) is False
+
+
+def test_h3_normalized_and_raw_titles_are_pooled():
+    # tokens may come from either title field — raw says "Sr. DE", normalized carries the rest
+    spec = _spec(titles=["Data Engineer"])
+    posting = _posting(title="Sr. Data Wrangler")
+    posting = posting.model_copy(update={"normalized_title": "Data Engineer"})
+    assert DeterministicFilterStrategy().filter(spec, _profile(), posting) is True
+
+
 # --------------------------------------------------------------------------- LLM strategy
 def test_llm_filter_true():
     llm = FakeLlm(json.dumps({"likely_fit": True, "reason": "matches role"}))

--- a/tests/test_handler_helpers.py
+++ b/tests/test_handler_helpers.py
@@ -12,6 +12,8 @@ from jobfetcher.handlers.pipeline import (
     _DEFAULT_PROFILE_PATH,
     _DEFAULT_SEARCH_CONFIG_PATH,
     resolve_db_url,
+    resolve_deadline,
+    resolve_max_workers,
     resolve_profile_path,
     resolve_run_date,
     resolve_run_id,
@@ -111,3 +113,44 @@ def test_resolve_run_date_defaults_to_utc_today():
 def test_resolve_run_date_raises_on_malformed_override():
     with pytest.raises(ValueError):
         resolve_run_date({"run_date": "not-a-date"})
+
+
+# --------------------------------------------------------------------------- H-2 knobs
+def test_resolve_max_workers_default_and_override():
+    assert resolve_max_workers({}) == 8
+    assert resolve_max_workers({"PIPELINE_MAX_WORKERS": "4"}) == 4
+    assert resolve_max_workers({"PIPELINE_MAX_WORKERS": "  16 "}) == 16
+
+
+def test_resolve_max_workers_rejects_junk_and_zero():
+    # negative: a misconfigured knob must fail loudly, never silently fall back
+    with pytest.raises(ValueError):
+        resolve_max_workers({"PIPELINE_MAX_WORKERS": "many"})
+    with pytest.raises(ValueError, match="must be >= 1"):
+        resolve_max_workers({"PIPELINE_MAX_WORKERS": "0"})
+
+
+def test_resolve_deadline_from_lambda_context():
+    class _Ctx:
+        def get_remaining_time_in_millis(self):
+            return 900_000  # 15 min left
+
+    deadline = resolve_deadline(_Ctx())
+    assert deadline is not None
+    assert not deadline.expired  # 900s - 60s margin is comfortably in the future
+
+
+def test_resolve_deadline_expired_when_context_nearly_out_of_time():
+    # negative: less remaining time than the safety margin → the deadline is already expired
+    class _Ctx:
+        def get_remaining_time_in_millis(self):
+            return 5_000  # 5s left < the 60s margin
+
+    deadline = resolve_deadline(_Ctx())
+    assert deadline is not None and deadline.expired
+
+
+def test_resolve_deadline_none_without_real_context():
+    # local runs / tests pass None (or an object without the Lambda method) → no time budget
+    assert resolve_deadline(None) is None
+    assert resolve_deadline(object()) is None

--- a/tests/test_handler_helpers.py
+++ b/tests/test_handler_helpers.py
@@ -154,3 +154,28 @@ def test_resolve_deadline_none_without_real_context():
     # local runs / tests pass None (or an object without the Lambda method) → no time budget
     assert resolve_deadline(None) is None
     assert resolve_deadline(object()) is None
+
+
+# --------------------------------------------------------------------------- H-3 gold filter
+def test_resolve_filter_strategy_default_and_explicit(monkeypatch):
+    from jobfetcher.adapters.filter_deterministic import DeterministicFilterStrategy
+    from jobfetcher.adapters.filter_llm import LlmFilterStrategy
+    from jobfetcher.handlers.pipeline import resolve_filter_strategy
+
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "test-key")  # llm path builds a client (no call)
+    assert isinstance(resolve_filter_strategy({}), DeterministicFilterStrategy)
+    assert isinstance(
+        resolve_filter_strategy({"GOLD_FILTER_STRATEGY": "deterministic"}),
+        DeterministicFilterStrategy,
+    )
+    assert isinstance(
+        resolve_filter_strategy({"GOLD_FILTER_STRATEGY": "LLM"}), LlmFilterStrategy
+    )
+
+
+def test_resolve_filter_strategy_rejects_junk():
+    # negative: a typo'd strategy must fail loudly, never silently fall back to a default
+    from jobfetcher.handlers.pipeline import resolve_filter_strategy
+
+    with pytest.raises(ValueError, match="GOLD_FILTER_STRATEGY"):
+        resolve_filter_strategy({"GOLD_FILTER_STRATEGY": "fuzzy"})

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -216,6 +216,57 @@ def test_land_silver_skips_on_dissection_error():
     assert repo.postings == {}
 
 
+# --------------------------------------------------------------------------- H-2 concurrency
+def test_ingest_dissects_concurrently():
+    """H-2 behavioral proof: 12 postings × a 0.15s dissect on 4 workers must beat the serial
+    wall-clock (~1.8s) by a wide margin — if the pool were secretly serial this fails."""
+    import time as _time
+
+    repo, store = FakeRepo(), FakeRawStore()
+
+    class _SlowDissector(Dissector):
+        def dissect(self, jd_text, metadata):
+            _time.sleep(0.15)
+            return super().dissect(jd_text, metadata)
+
+    jobs = [_job(f"j{i}") for i in range(12)]
+    t0 = _time.monotonic()
+    summary = ingest(
+        _spec(), run_id="r", source_adapter=FakeSource(jobs), raw_store=store, repo=repo,
+        dissector=_SlowDissector(FakeLlm(CANNED_LLM_JSON), model_id="test-model"),
+        max_workers=4,
+    )
+    elapsed = _time.monotonic() - t0
+    assert summary["silvered"] == 12 and summary["deferred"] == 0
+    assert len(repo.postings) == 12  # every result was saved (main-thread writes)
+    assert elapsed < 1.2, f"expected concurrent (<1.2s), got {elapsed:.2f}s (serial ~1.8s)"
+
+
+def test_ingest_defers_on_expired_deadline():
+    """H-2 negative: a deadline that is already past → NO dissection starts (zero LLM calls),
+    everything is counted `deferred`, and the run returns cleanly instead of timing out."""
+    from jobfetcher.core.ingest import Deadline
+
+    repo, store = FakeRepo(), FakeRawStore()
+
+    class _CountingDissector(Dissector):
+        calls = 0
+
+        def dissect(self, jd_text, metadata):
+            type(self).calls += 1
+            return super().dissect(jd_text, metadata)
+
+    summary = ingest(
+        _spec(), run_id="r", source_adapter=FakeSource([_job("a"), _job("b")]),
+        raw_store=store, repo=repo,
+        dissector=_CountingDissector(FakeLlm(CANNED_LLM_JSON), model_id="test-model"),
+        deadline=Deadline(0),  # expired immediately
+    )
+    assert summary["deferred"] == 2 and summary["silvered"] == 0
+    assert _CountingDissector.calls == 0  # no LLM work started past the deadline
+    assert summary["bronzed"] == 2  # bronze still landed — only the LLM half is deferred
+
+
 def test_land_silver_skips_on_llm_error():
     # ERR-006 negative: a provider-level LlmError (a 503 that outlived the client retries)
     # must be isolated exactly like a DissectionError — skip the posting, never crash the
@@ -242,7 +293,7 @@ def test_ingest_end_to_end_summary():
         _spec(), run_id="r", source_adapter=src, raw_store=store, repo=repo,
         dissector=_dissector(),
     )
-    assert summary == {"fetched": 2, "bronzed": 2, "silvered": 2, "skipped": 0, "already": 0}
+    assert summary == {"fetched": 2, "bronzed": 2, "silvered": 2, "skipped": 0, "already": 0, "deferred": 0}
     assert set(repo.postings) == {"jsearch:a", "jsearch:b"}
 
 
@@ -258,7 +309,7 @@ def test_ingest_counts_dissection_skips():
         _spec(), run_id="r", source_adapter=FakeSource([_job("a")]),
         raw_store=store, repo=repo, dissector=_D(FakeLlm()),
     )
-    assert summary == {"fetched": 1, "bronzed": 1, "silvered": 0, "skipped": 1, "already": 0}
+    assert summary == {"fetched": 1, "bronzed": 1, "silvered": 0, "skipped": 1, "already": 0, "deferred": 0}
 
 
 def test_ingest_rerun_does_not_redissect_existing_posting():
@@ -280,12 +331,12 @@ def test_ingest_rerun_does_not_redissect_existing_posting():
         _spec(), run_id="r1", source_adapter=FakeSource([_job("a")]),
         raw_store=store, repo=repo, dissector=dissector,
     )
-    assert first == {"fetched": 1, "bronzed": 1, "silvered": 1, "skipped": 0, "already": 0}
+    assert first == {"fetched": 1, "bronzed": 1, "silvered": 1, "skipped": 0, "already": 0, "deferred": 0}
     assert dissector.calls == 1
 
     second = ingest(
         _spec(), run_id="r2", source_adapter=FakeSource([_job("a")]),
         raw_store=store, repo=repo, dissector=dissector,
     )
-    assert second == {"fetched": 1, "bronzed": 1, "silvered": 0, "skipped": 0, "already": 1}
+    assert second == {"fetched": 1, "bronzed": 1, "silvered": 0, "skipped": 0, "already": 1, "deferred": 0}
     assert dissector.calls == 1  # NOT re-dissected on the re-run

--- a/tests/test_integration_ingest.py
+++ b/tests/test_integration_ingest.py
@@ -194,7 +194,7 @@ def test_full_ingest_end_to_end(repo, raw_store):
         raw_store=raw_store, repo=repo,
         dissector=Dissector(FakeLlm(CANNED_LLM_JSON), model_id="test-model"),
     )
-    assert summary == {"fetched": 2, "bronzed": 2, "silvered": 2, "skipped": 0, "already": 0}
+    assert summary == {"fetched": 2, "bronzed": 2, "silvered": 2, "skipped": 0, "already": 0, "deferred": 0}
     assert repo.get_posting(f"jsearch:{id1}") is not None
 
 

--- a/tests/test_scorer.py
+++ b/tests/test_scorer.py
@@ -224,14 +224,14 @@ def _scorer_for(scores):
 
 def test_vg8_threshold_0_surfaces_all():
     repo = _FakeScoreRepo(_profile_row(0), _candidates(), None)
-    summary = score_gold(run_id="r", repo=repo, scorer=_scorer_for([30, 65, 90]))
-    assert summary == {"gold": 3, "scored": 3, "surfaced": 3, "failed": 0}
+    summary = score_gold(run_id="r", repo=repo, scorer=_scorer_for([30, 65, 90]), max_workers=1)
+    assert summary == {"gold": 3, "scored": 3, "surfaced": 3, "failed": 0, "deferred": 0}
     assert all(v["fit_category"] == "strong_fit" for v in repo.saved.values())
 
 
 def test_vg8_threshold_above_all_surfaces_none():
     repo = _FakeScoreRepo(_profile_row(101), _candidates(), None)
-    summary = score_gold(run_id="r", repo=repo, scorer=_scorer_for([30, 65, 90]))
+    summary = score_gold(run_id="r", repo=repo, scorer=_scorer_for([30, 65, 90]), max_workers=1)
     assert summary["surfaced"] == 0
     assert not any(v["fit_category"] == "strong_fit" for v in repo.saved.values())
 
@@ -240,7 +240,8 @@ def test_vg8_threshold_60_splits_in_between():
     # SAME scores (30, 65, 90), only the config threshold changes → a DIFFERENT surfaced set,
     # with NO code change. This is the VG8 proof.
     repo = _FakeScoreRepo(_profile_row(60), _candidates(), None)
-    summary = score_gold(run_id="r", repo=repo, scorer=_scorer_for([30, 65, 90]))
+    # max_workers=1: the FakeLlm replies map to candidates by call order (order-sensitive)
+    summary = score_gold(run_id="r", repo=repo, scorer=_scorer_for([30, 65, 90]), max_workers=1)
     assert summary["surfaced"] == 2  # 65 and 90 clear 60; 30 does not
     assert repo.saved["c-high"]["fit_category"] == "strong_fit"
     assert repo.saved["c-mid"]["fit_category"] == "strong_fit"
@@ -261,8 +262,9 @@ def test_score_gold_skips_failed_scoring_and_continues():
             return ScoreResult.model_validate(json.loads(_score_json(80)))
 
     repo = _FakeScoreRepo(_profile_row(60), _candidates(), None)
-    summary = score_gold(run_id="r", repo=repo, scorer=_OneBoomScorer())
-    assert summary == {"gold": 3, "scored": 2, "surfaced": 2, "failed": 1}
+    # max_workers=1: "the 2nd call" must map to p-mid deterministically (order-sensitive)
+    summary = score_gold(run_id="r", repo=repo, scorer=_OneBoomScorer(), max_workers=1)
+    assert summary == {"gold": 3, "scored": 2, "surfaced": 2, "failed": 1, "deferred": 0}
     assert repo.status["p-mid"] == "gold_candidate"  # the failed one is NOT marked scored
 
 
@@ -273,7 +275,29 @@ def test_score_gold_skips_llm_transport_error():
 
     repo = _FakeScoreRepo(_profile_row(60), [("p", "c", _dissected())], None)
     summary = score_gold(run_id="r", repo=repo, scorer=_BoomScorer())
-    assert summary == {"gold": 1, "scored": 0, "surfaced": 0, "failed": 1}
+    assert summary == {"gold": 1, "scored": 0, "surfaced": 0, "failed": 1, "deferred": 0}
+
+
+def test_score_gold_defers_on_expired_deadline():
+    """H-2 negative: an expired deadline → all candidates deferred, no scorer calls, no saves;
+    the run returns cleanly for the idempotent re-run to finish."""
+    from jobfetcher.core.ingest import Deadline
+
+    class _CountingScorer:
+        calls = 0
+
+        def score(self, dissected, profile):
+            type(self).calls += 1
+            return ScoreResult.model_validate(json.loads(_score_json(80)))
+
+    repo = _FakeScoreRepo(_profile_row(60), _candidates(), None)
+    summary = score_gold(
+        run_id="r", repo=repo, scorer=_CountingScorer(), deadline=Deadline(0)
+    )
+    assert summary == {"gold": 3, "scored": 0, "surfaced": 0, "failed": 0, "deferred": 3}
+    assert _CountingScorer.calls == 0
+    assert repo.saved == {}  # nothing written
+    assert all(v == "gold_candidate" for v in repo.status.values())  # nothing marked
 
 
 def test_score_gold_uses_default_knobs_when_null():
@@ -281,5 +305,5 @@ def test_score_gold_uses_default_knobs_when_null():
     row = {"profile": _profile().model_dump(), "threshold": None,
            "hard_floor": None, "near_miss_band": None}
     repo = _FakeScoreRepo(row, _candidates(), None)
-    summary = score_gold(run_id="r", repo=repo, scorer=_scorer_for([30, 65, 90]))
+    summary = score_gold(run_id="r", repo=repo, scorer=_scorer_for([30, 65, 90]), max_workers=1)
     assert summary["surfaced"] == 2  # default threshold 60 → 65 & 90 surface


### PR DESCRIPTION
## Why this PR
#15 (H-2) and #16 (H-3) were merged, but **into their stacked base branches, not `main`** (the auto-retarget only happens when the base branch is deleted first). `main` currently carries only H-1 (#14).

This lands the exact commits already reviewed + merged in #15 and #16 — no new content:
- `394477c` perf(pipeline): H-2 — concurrent LLM stages + deadline guard + no platform blind-retry (ERR-007)
- `6ba7296` fix(gold): H-3 — subset title matching + config-selectable filter strategy

After this, `main` = H-1+H-2+H-3 and the M1 live re-validation can deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pipeline runs can now continue with partial results when time is low, and skipped items are reported separately.
  * You can choose between deterministic or AI-based filtering for gold jobs.

* **Bug Fixes**
  * Job title matching is stricter, reducing false positives from loosely related titles.
  * AI request handling is more resilient, with automatic retries for temporary failures and clearer failure handling for invalid responses.

* **Performance**
  * Ingesting and scoring can now run in parallel for faster processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->