### PR TITLE
fix(search): employment_types is an enum + actually wired to JSearch (v0.3.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The ***why*** behind every entry is the [session decision journal](docs/01-sessi
 
 *Next migration candidate (P2): the **digest email UX** — the format is poor and the job apply-links must be visible.*
 
+## [v0.3.1] — 2026-07-03 — employment_types fix (first patch release)
+
+### Fixed
+- **`employment_types` was a silent no-op with no validation** — it was typed `list[str]` (any string accepted) **and** never actually passed to the JSearch query. Now it's an **`EmploymentType` enum** (`FULLTIME`/`PARTTIME`/`CONTRACTOR`/`INTERN`) — a typo fails **loudly at config-load** (like `date_posted`/`remote`) — **and** it's wired into the `/search` request, so setting it actually narrows results. `[]` still means no filter.
+
 ## [v0.3.0] — 2026-07-03 — user-customizable settings (no redeploy)
 
 **Toward "fully customizable per user."** The job-seeker settings became genuinely user-owned + editable without a rebuild — a settings change is now one command, not a deploy.

--- a/config/search_config.sample.yml
+++ b/config/search_config.sample.yml
@@ -34,7 +34,7 @@ targeting:
 # ── Knobs — also explicit, no silent defaults ─────────────────────────────
 date_posted: month               # all | today | 3days | week | month  (30-day backfill)
 language: en                     # English metadata + populates job_city/country + the UTC ts
-employment_types: []             # e.g. ["FULLTIME"]; [] = no employment-type filter
+employment_types: []             # FULLTIME | PARTTIME | CONTRACTOR | INTERN; [] = no filter (a bad value fails at load)
 remote: "off"                    # "off" (on-site) | "include" (flag) | "only" (remote_jobs_only)
 
 # ── How strict is your shortlist? (the three matching knobs, each 0..100) ──

--- a/src/jobfetcher/adapters/jsearch_source.py
+++ b/src/jobfetcher/adapters/jsearch_source.py
@@ -90,17 +90,20 @@ def get_key(spec: SearchSpec) -> str:
 # --------------------------------------------------------------------------- HTTP fetch
 def _fetch_page(query: str, country: str, page: int, spec: SearchSpec, key: str) -> dict:
     """One JSearch `/search` call → parsed JSON. Productionized from the probe's `fetch`."""
-    params = urllib.parse.urlencode(
-        {
-            "query": query,
-            "country": country,
-            "page": str(page),
-            "num_pages": "1",
-            "date_posted": spec.date_posted.value,
-            "language": spec.language,
-            "remote_jobs_only": "true" if spec.remote is RemoteMode.only else "false",
-        }
-    )
+    query_params = {
+        "query": query,
+        "country": country,
+        "page": str(page),
+        "num_pages": "1",
+        "date_posted": spec.date_posted.value,
+        "language": spec.language,
+        "remote_jobs_only": "true" if spec.remote is RemoteMode.only else "false",
+    }
+    # Employment-type filter (only when set) — the JSearch `/search` param is a comma-separated
+    # list of FULLTIME|PARTTIME|CONTRACTOR|INTERN. Empty spec = no filter (param omitted).
+    if spec.employment_types:
+        query_params["employment_types"] = ",".join(e.value for e in spec.employment_types)
+    params = urllib.parse.urlencode(query_params)
     req = urllib.request.Request(
         f"https://{HOST}/search?{params}",
         headers={"X-RapidAPI-Key": key, "X-RapidAPI-Host": HOST},

--- a/src/jobfetcher/core/search_spec.py
+++ b/src/jobfetcher/core/search_spec.py
@@ -38,6 +38,16 @@ class RemoteMode(str, Enum):
     only = "only"        # remote only (remote_jobs_only=true)
 
 
+class EmploymentType(str, Enum):
+    """JSearch's employment-type vocabulary — the only values the `/search` filter accepts.
+    An enum (not a free `str`) so a typo fails loudly at config-load, like DatePosted/RemoteMode."""
+
+    fulltime = "FULLTIME"
+    parttime = "PARTTIME"
+    contractor = "CONTRACTOR"
+    intern = "INTERN"
+
+
 class Targeting(BaseModel):
     """The four user-named fields. All required; titles/countries must be non-empty."""
 
@@ -93,7 +103,7 @@ class SearchSpec(BaseModel):
     # knobs (explicit — no defaults)
     date_posted: DatePosted
     language: str
-    employment_types: list[str]          # e.g. ["FULLTIME"]; [] = no employment-type filter
+    employment_types: list[EmploymentType]  # FULLTIME|PARTTIME|CONTRACTOR|INTERN; [] = no filter
     remote: RemoteMode
 
     # Shortlist strictness — the three "how strict is my shortlist" knobs (all user-set, all

--- a/tests/test_jsearch_source.py
+++ b/tests/test_jsearch_source.py
@@ -16,7 +16,8 @@ from jobfetcher.core.ports import SourceError
 from jobfetcher.core.search_spec import SearchSpec
 
 
-def _spec(*, titles=("data engineer",), countries=("sa",), max_pages=3, budget=100) -> SearchSpec:
+def _spec(*, titles=("data engineer",), countries=("sa",), max_pages=3, budget=100,
+          employment_types=()) -> SearchSpec:
     return SearchSpec.model_validate(
         {
             "source": "jsearch",
@@ -30,7 +31,7 @@ def _spec(*, titles=("data engineer",), countries=("sa",), max_pages=3, budget=1
             },
             "date_posted": "week",
             "language": "en",
-            "employment_types": [],
+            "employment_types": list(employment_types),
             "remote": "off",
             "threshold": 60, "hard_floor": 50, "near_miss_band": 10,
             "budget": {"max_pages_per_query": max_pages, "request_budget_per_run": budget},
@@ -293,3 +294,43 @@ def test_get_key_json_secret_without_api_key_raises(monkeypatch):
     monkeypatch.setitem(__import__("sys").modules, "boto3", _FakeBoto3)
     with pytest.raises(SourceError, match="no 'api_key'"):
         get_key(_spec())
+
+
+# --------------------------------------------------------------------------- employment_types (v0.3.1)
+def _capture_fetch_url(monkeypatch) -> dict:
+    """Intercept `_fetch_page`'s HTTP call → capture the request URL (with query params)."""
+    captured: dict = {}
+
+    class _Resp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def read(self):
+            return b'{"data": []}'
+
+    def _fake_urlopen(req, timeout=0):
+        captured["url"] = req.full_url
+        return _Resp()
+
+    monkeypatch.setattr(jsearch_source.urllib.request, "urlopen", _fake_urlopen)
+    return captured
+
+
+def test_fetch_page_wires_employment_types_when_set(monkeypatch):
+    # the filter now actually reaches the JSearch query (it was defined but never sent)
+    from jobfetcher.core.search_spec import EmploymentType
+
+    captured = _capture_fetch_url(monkeypatch)
+    spec = _spec(employment_types=(EmploymentType.fulltime, EmploymentType.contractor))
+    jsearch_source._fetch_page("data engineer", "sa", 1, spec, "k")
+    assert "employment_types=FULLTIME%2CCONTRACTOR" in captured["url"]  # comma url-encoded
+
+
+def test_fetch_page_omits_employment_types_when_empty(monkeypatch):
+    # [] = no filter → the param is absent entirely (not an empty string)
+    captured = _capture_fetch_url(monkeypatch)
+    jsearch_source._fetch_page("data engineer", "sa", 1, _spec(employment_types=()), "k")
+    assert "employment_types" not in captured["url"]

--- a/tests/test_search_spec.py
+++ b/tests/test_search_spec.py
@@ -159,6 +159,22 @@ def test_blank_job_title_is_loud():
         SearchSpec.model_validate(data)
 
 
+def test_valid_employment_types_load(monkeypatch):
+    data = _valid_spec_dict()
+    data["employment_types"] = ["FULLTIME", "CONTRACTOR"]
+    spec = SearchSpec.model_validate(data)
+    assert [e.value for e in spec.employment_types] == ["FULLTIME", "CONTRACTOR"]
+
+
+@pytest.mark.parametrize("bad", ["fulltime", "FULL_TIME", "PERMANENT", "full-time"])
+def test_bad_employment_type_is_loud(bad):
+    # the v0.3.1 fix: an unknown/typo value now fails at load (was: silently accepted + ignored)
+    data = _valid_spec_dict()
+    data["employment_types"] = [bad]
+    with pytest.raises(ValidationError):
+        SearchSpec.model_validate(data)
+
+
 def test_unknown_key_is_loud():
     data = _valid_spec_dict()
     data["unexpected"] = "nope"


### PR DESCRIPTION
## The latent bug (two layers)
`employment_types` was typed `list[str]` — **any string silently accepted** — *and* it was **never passed to the JSearch query** (defined but dead). So a typo did nothing, and even a correct value did nothing.

## Fix
- **Validation:** new `EmploymentType(str, Enum)` (`FULLTIME`/`PARTTIME`/`CONTRACTOR`/`INTERN`); `employment_types: list[EmploymentType]` → a typo now **fails loudly at config-load**, like `date_posted`/`remote`. No custom validator (mirrors the existing enums).
- **Wiring:** `_fetch_page` now adds `employment_types` to the `/search` params (comma-joined `.value`) when set; `[]` omits it → it **actually narrows results** now.

## Tests
- valid values load; `fulltime`/`FULL_TIME`/`PERMANENT`/`full-time` → `ValidationError`; query includes `employment_types=FULLTIME,CONTRACTOR` when set, omits when `[]`. **243 green, ruff clean.**

First **patch** release under the new convention (small fix → `v0.3.1`, not a minor bump). Ships after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Employment type filters are now validated, so invalid values fail fast during config loading instead of being ignored.
  * Search requests now correctly apply the selected employment types, narrowing results as expected.
  * An empty employment type list still means “no filter.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->