### PR TITLE
feat(reassess): re-score existing jobs on an updated profile, no re-fetch (ADR-0023)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The ***why*** behind every entry is the [session decision journal](docs/01-sessi
 
 ## [Unreleased]
 
+### Added — reassess / replay (re-score existing jobs on an updated profile, no re-fetch)
+- **[ADR-0023] A `{"mode":"reassess"}` handler mode** — re-scores your already-scored postings against the **current** profile with **zero JSearch calls** (the medallion's immutable-bronze → replay). When your profile improves (a new skill), a job that was a `stretch` can **graduate** to `strong_fit`. `save_score` already carried the old score into `previous_score`; this wires the replay that uses it. Flow: edit `profile.local.yml` → `push_config.py` → invoke `{"mode":"reassess"}`. New `Repository.get_scored_for_reassess()` + `core.ingest.reassess()` (same concurrency/deadline/retry as scoring) + a pure `resolve_mode`. Reports `{reassessed, graduated, downgraded, unchanged, …}` + a `graduations` list. *(The "what graduated" email rides the email-UX unit; a query/filter surface is the next capability.)*
+
 *Next migration candidate (P2): the **digest email UX** — the format is poor and the job apply-links must be visible.*
 
 ## [v0.3.1] — 2026-07-03 — employment_types fix (first patch release)

--- a/docs/adr/0023-reassess-replay.md
+++ b/docs/adr/0023-reassess-replay.md
@@ -1,0 +1,37 @@
+# ADR-0023 — Reassess / replay: re-score existing jobs on an updated profile (no re-fetch)
+
+**Status:** Accepted
+**Date:** 2026-07-03
+
+## Context
+
+The candidate's profile changes over time — a new skill, a finished project, a certification. When it does, jobs already in the system should be **re-evaluated**: a posting that scored as a `stretch` last week can become a `strong_fit` today. Tarig surfaced this from real use: *"give me an option to re-run/reassess the saved records on new input — I made progress in a skill, so this posting should now be a strong fit."*
+
+This is the medallion architecture's designed-in **immutable-bronze → replay** property: bronze is the permanent, append-only record of every job ever fetched; silver/gold/score are **pure functions** over it. So re-scoring is a **replay over existing data with zero JSearch calls** — only LLM scoring tokens (pennies). It also realizes the **graduation half of the old M4 hypothesis** ("watch → re-score → graduate when you learn a skill"), re-derived from usage via the P2 protocol.
+
+**The schema + write path already support it** (they were built anticipating this): `score.previous_score` is commented *"for near-miss re-scoring"*, and `save_score` (`repository_postgres.py`) already carries the existing score into `previous_score` on an upsert conflict. The **only** missing piece was that scoring skips already-scored postings (`score_gold` reads `status='gold_candidate'` and marks them `'scored'`), so nothing re-scores today.
+
+## Decision
+
+Add a **`reassess` mode** to the single Lambda handler. Flow (builds on the runtime config, ADR-0022): **edit `profile.local.yml` → `python scripts/push_config.py` → invoke `{"mode":"reassess"}`.**
+
+- **`Repository.get_scored_for_reassess()`** — returns every `status='scored'` posting with its **current** `score` + `fit_category` (so the old→new delta is computable).
+- **`core.ingest.reassess(...)`** — re-scores that set against the current profile, structurally mirroring `score_gold`'s **concurrent** loop (H-2: LLM calls on a thread pool, all DB writes on the main thread; H-1 failure isolation + retry; the deadline guard). Each `save_score(..., previous_score=old_score)` moves the old score into `previous_score`. Returns `{reassessed, graduated, downgraded, unchanged, failed, deferred}` + a `graduations` list — a **graduation** = a posting that newly reached at/above the threshold (`old < threshold <= new`).
+- **Handler `mode` routing** — `event["mode"]=="reassess"` (via the pure `resolve_mode`) runs `reassess()` after syncing the profile from config, then returns its report; it **skips fetch, gold, and notify**. Default (no mode) = the normal pipeline, unchanged.
+- **Scope (correct by design):** only the `scored` set is re-scored. A *skill* change doesn't alter gold membership (gold = title/location/avoid-keyword, not skills), so this is exactly right for the graduation use case. Re-running **gold** for a targeting/avoid change is a separate, later concern.
+
+## Alternatives considered
+
+- **Re-fetch then re-score.** Rejected: wasteful (JSearch quota + tokens) and it *throws away* the immutable-bronze value — the whole point is that history is already stored and replayable.
+- **A separate scoring service / queue.** Rejected: over-infra for a single daily user; the existing concurrent `score_gold` machinery already does exactly this work.
+- **Auto-reassess on every normal run.** Rejected: wastes LLM tokens re-scoring unchanged jobs when the profile didn't change. Kept as an **explicit mode**; a later refinement can auto-trigger only when a profile-hash change is detected.
+- **Score-history table now.** Deferred: today `score` keeps *current + previous* (one step), enough to report graduations. A full append-only `score_history` (for "45→62→78 over time" charts) is a later add, alongside the query/filter capability.
+
+## Consequences
+
+- A profile improvement re-evaluates the whole backlog for **~$0** (no re-fetch) and reports which jobs **graduated** — the tool's core intelligence ("my progress changes my matches").
+- `previous_score` is populated on every reassess, so the before→after is persisted + queryable.
+- New event shape: `{"mode":"reassess"}`. New repo method + orchestrator; the handler's default path is untouched.
+- **Follow-ons (noted, not built here):** the "what graduated" **digest email** rides the email-UX unit (don't entangle the notifier rework); the **query/filter** surface (export to SQLite/CSV → Datasette/Excel) is the next capability; a `score_history` table if time-series is wanted.
+
+Full reasoning: [journal](../01-session-decision-journal.md) · plan §41. Related: [ADR-0022](0022-runtime-config-in-s3.md) (the edit→push flow), [ADR-0016](0016-llm-dissection-at-silver.md) + the immutable-bronze/replay principle in [02-architecture](../02-architecture.md).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -28,5 +28,6 @@ These are the **foundational** decisions made during the design session — the 
 | [0020](0020-lambda-deployment-packaging.md) | Lambda deployment packaging: vendor Linux wheels via `pip --platform` (no Docker), bundle + prune boto3, direct zip | Accepted · ✅ Validated live (v0.1.0) |
 | [0021](0021-m1-pipeline-hardening.md) | M1 pipeline hardening: LLM retry+jitter & symmetric isolation · in-Lambda concurrency + deadline guard · subset-title gold filter + selectable LLM filter | Accepted · ✅ Validated live (v0.2.0) |
 | [0022](0022-runtime-config-in-s3.md) | Runtime config in S3 (not bundled): the Lambda reads the search spec + profile from S3 each run → change settings via `push_config.py`, no redeploy | Accepted |
+| [0023](0023-reassess-replay.md) | Reassess/replay: a `{"mode":"reassess"}` re-scores existing jobs against the updated profile with **no re-fetch** (immutable-bronze replay) → jobs graduate as skills grow | Accepted |
 
 > Full reasoning narrative: [01-session-decision-journal](../01-session-decision-journal.md). Crisp decision list: [ledgers/decisions-locked](../ledgers/decisions-locked.md).

--- a/src/jobfetcher/adapters/repository_postgres.py
+++ b/src/jobfetcher/adapters/repository_postgres.py
@@ -306,6 +306,40 @@ class PostgresRepository:
             (row["posting_id"], row["cluster_id"], _dissected_from_row(row)) for row in rows
         ]
 
+    def get_scored_for_reassess(
+        self,
+    ) -> list[tuple[str, str, DissectedPosting, int, str]]:
+        """The reassess set (ADR-0023): every already-scored posting + its CURRENT score and
+        fit_category, so a replay can re-score against the updated profile and report the
+        old→new delta. Returns `(posting_id, cluster_id, dissected, current_score,
+        current_fit_category)`. Ordered by posting_id for a deterministic run.
+
+        Only `status='scored'` postings are returned — these are the ones with a prior score to
+        graduate. (A skill change doesn't alter gold membership, so re-scoring the scored set is
+        the right scope; re-running gold for a targeting/avoid change is a separate concern.)"""
+        s, p = tables.score, tables.posting
+        stmt = (
+            select(p, s.c.score, s.c.fit_category)
+            .select_from(p.join(s, p.c.cluster_id == s.c.cluster_id))
+            .where(p.c.status == "scored")
+            .order_by(p.c.posting_id)
+        )
+        try:
+            with self.engine.connect() as conn:
+                rows = conn.execute(stmt).mappings().all()
+        except SQLAlchemyError as e:
+            raise RepositoryError(f"get_scored_for_reassess failed: {e}") from e
+        return [
+            (
+                row["posting_id"],
+                row["cluster_id"],
+                _dissected_from_row(row),
+                row["score"],
+                row["fit_category"],
+            )
+            for row in rows
+        ]
+
     def save_score(
         self,
         *,

--- a/src/jobfetcher/core/ingest.py
+++ b/src/jobfetcher/core/ingest.py
@@ -373,6 +373,24 @@ def derive_fit_category(
     return "misaligned"
 
 
+def _load_profile_and_knobs(
+    repo: "Repository", user_id: str
+) -> tuple["Profile", int, int, int]:
+    """Load the profile + its runtime threshold/floor/band from the `profile` row (the single
+    authority, VG8); NULL knobs fall back to the documented defaults. Shared by `score_gold`
+    and `reassess`. Raises `RepositoryError` if there is no profile row."""
+    row = repo.get_profile(user_id)
+    if row is None:
+        raise RepositoryError(f"no profile row for user_id={user_id!r} — cannot score")
+    profile = Profile.from_jsonb(row["profile"])
+    threshold = row["threshold"] if row["threshold"] is not None else _DEFAULT_THRESHOLD
+    hard_floor = row["hard_floor"] if row["hard_floor"] is not None else _DEFAULT_HARD_FLOOR
+    near_miss_band = (
+        row["near_miss_band"] if row["near_miss_band"] is not None else _DEFAULT_NEAR_MISS_BAND
+    )
+    return profile, threshold, hard_floor, near_miss_band
+
+
 def score_gold(
     *,
     run_id: str,
@@ -403,17 +421,7 @@ def score_gold(
     **Concurrency model (H-2):** scoring calls (pure LLM I/O) run on up to `max_workers`
     threads; the `save_score`/`mark_scored` writes stay on the main thread.
     """
-    row = repo.get_profile(user_id)
-    if row is None:
-        raise RepositoryError(f"no profile row for user_id={user_id!r} — cannot score")
-    profile = Profile.from_jsonb(row["profile"])
-    threshold = row["threshold"] if row["threshold"] is not None else _DEFAULT_THRESHOLD
-    hard_floor = row["hard_floor"] if row["hard_floor"] is not None else _DEFAULT_HARD_FLOOR
-    near_miss_band = (
-        row["near_miss_band"]
-        if row["near_miss_band"] is not None
-        else _DEFAULT_NEAR_MISS_BAND
-    )
+    profile, threshold, hard_floor, near_miss_band = _load_profile_and_knobs(repo, user_id)
 
     candidates = repo.get_gold_candidates()
     scored = 0
@@ -476,6 +484,119 @@ def score_gold(
         "surfaced": surfaced,
         "failed": failed,
         "deferred": deferred,
+    }
+
+
+def reassess(
+    *,
+    run_id: str,
+    repo: "Repository",
+    scorer: "Scorer",
+    user_id: str = DEFAULT_USER_ID,
+    max_workers: int = DEFAULT_MAX_WORKERS,
+    deadline: Deadline | None = None,
+) -> dict[str, Any]:
+    """Replay scoring over the already-scored postings against the **current** profile — no
+    fetch, no gold (ADR-0023). The medallion's immutable-bronze → replay property: when the
+    user's profile improves (a new skill), a posting that was a `stretch`/`near_miss` can
+    **graduate** to `strong_fit` with **zero JSearch calls** (only LLM scoring tokens).
+
+    Same concurrency model as `score_gold` (H-2): LLM calls on `max_workers` threads, all DB
+    writes on the main thread; `save_score` carries the old score into `previous_score`.
+    Failure-isolated + deadline-guarded identically.
+
+    Returns `{reassessed, graduated, downgraded, unchanged, failed, deferred}` plus a
+    `graduations` list (`posting_id/title/company/old_score→new_score/old_cat→new_cat`) — a
+    **graduation** = a posting that newly reached at/above the threshold (`old < threshold <=
+    new`). The digest of these rides the email-UX unit; here they are reported + persisted."""
+    profile, threshold, hard_floor, near_miss_band = _load_profile_and_knobs(repo, user_id)
+    targets = repo.get_scored_for_reassess()
+
+    reassessed = 0
+    graduated = 0
+    downgraded = 0
+    unchanged = 0
+    failed = 0
+    deferred = 0
+    graduations: list[dict[str, Any]] = []
+
+    def _rescore_task(target: tuple) -> Any:
+        posting_id = target[0]
+        if deadline is not None and deadline.expired:
+            return _DEFERRED
+        try:
+            return scorer.score(target[2], profile)  # target[2] = dissected
+        except (ScorerError, LlmError) as exc:
+            log.warning("reassess scoring failed for %s (run_id=%s): %s", posting_id, run_id, exc)
+            return None
+
+    if targets:
+        with ThreadPoolExecutor(max_workers=max_workers) as pool:
+            futures = {pool.submit(_rescore_task, t): t for t in targets}
+            for fut in as_completed(futures):
+                result = fut.result()
+                if result is _DEFERRED:
+                    deferred += 1
+                    continue
+                if result is None:
+                    failed += 1
+                    continue
+                posting_id, cluster_id, dissected, old_score, old_cat = futures[fut]
+                new_cat = derive_fit_category(
+                    result.score,
+                    threshold=threshold,
+                    hard_floor=hard_floor,
+                    near_miss_band=near_miss_band,
+                )
+                repo.save_score(  # main thread — the only writer; carries old → previous_score
+                    cluster_id=cluster_id,
+                    score=result.score,
+                    fit_category=new_cat,
+                    strengths=result.strengths,
+                    gaps=result.gaps,
+                    strategic_assessment=result.strategic_assessment,
+                    poster_type=result.poster_type,
+                    legitimacy_verified=result.legitimacy_verified,
+                    previous_score=old_score,
+                )
+                reassessed += 1
+                if old_score < threshold <= result.score:  # crossed UP → graduated
+                    graduated += 1
+                    graduations.append(
+                        {
+                            "posting_id": posting_id,
+                            "title": dissected.normalized_title or dissected.raw_title,
+                            "old_score": old_score,
+                            "new_score": result.score,
+                            "old_category": old_cat,
+                            "new_category": new_cat,
+                        }
+                    )
+                elif old_score >= threshold > result.score:  # crossed DOWN → downgraded
+                    downgraded += 1
+                else:  # both above or both below the threshold
+                    unchanged += 1
+    if deferred:
+        log.warning(
+            "reassess deadline reached (run_id=%s): %d posting(s) deferred to the next run",
+            run_id,
+            deferred,
+        )
+    log.info(
+        "reassess done (run_id=%s): %d reassessed, %d graduated, %d downgraded",
+        run_id,
+        reassessed,
+        graduated,
+        downgraded,
+    )
+    return {
+        "reassessed": reassessed,
+        "graduated": graduated,
+        "downgraded": downgraded,
+        "unchanged": unchanged,
+        "failed": failed,
+        "deferred": deferred,
+        "graduations": graduations,
     }
 
 

--- a/src/jobfetcher/handlers/pipeline.py
+++ b/src/jobfetcher/handlers/pipeline.py
@@ -45,6 +45,7 @@ from ..core.ingest import (
     apply_gold_filter,
     ingest,
     notify,
+    reassess,
     score_gold,
 )
 from ..core.profile import Profile
@@ -110,6 +111,15 @@ def resolve_run_id(event: dict[str, Any] | None) -> str:
     if event and isinstance(event.get("run_id"), str) and event["run_id"].strip():
         return event["run_id"].strip()
     return uuid.uuid4().hex[:8]
+
+
+def resolve_mode(event: dict[str, Any] | None) -> str:
+    """The run mode (ADR-0023): `event['mode']` lowercased, else `""` (the normal
+    fetch→gold→score→notify pipeline). `"reassess"` = replay scoring over existing scored
+    postings against the current profile, no fetch. Pure."""
+    if event and isinstance(event.get("mode"), str):
+        return event["mode"].strip().lower()
+    return ""
 
 
 def resolve_run_date(event: dict[str, Any] | None) -> date:
@@ -185,6 +195,7 @@ def handler(event: dict[str, Any] | None = None, context: Any = None) -> dict[st
     event = event or {}
     run_id = resolve_run_id(event)
     run_date = resolve_run_date(event)
+    mode = resolve_mode(event)
     user_id = DEFAULT_USER_ID
     rlog = logging.LoggerAdapter(log, {"run_id": run_id})
 
@@ -227,6 +238,29 @@ def handler(event: dict[str, Any] | None = None, context: Any = None) -> dict[st
             OpenAICompatLlmClient(LlmConfig(model=_SCORE_MODEL)), model_id=_SCORE_MODEL
         )
         notifier = SesNotifier()
+
+        # --- reassess mode (ADR-0023): replay scoring over the already-scored postings against
+        # the profile just synced from config — NO fetch, NO gold, NO notify. The medallion's
+        # immutable-bronze replay: a profile improvement can graduate old jobs with zero JSearch
+        # spend. Returns its own report and exits before the normal pipeline. ---
+        if mode == "reassess":
+            rlog.info("mode=reassess start — replay scoring, no fetch")
+            reassess_report = reassess(
+                run_id=run_id,
+                repo=repo,
+                scorer=scorer,
+                user_id=user_id,
+                max_workers=max_workers,
+                deadline=deadline,
+            )
+            rlog.info("mode=reassess done %s", reassess_report)
+            return {
+                "statusCode": 200,
+                "run_id": run_id,
+                "run_date": run_date.isoformat(),
+                "mode": "reassess",
+                "reassess": reassess_report,
+            }
 
         # --- the pipeline, in sequence (each stage is idempotent via its own upserts) ---
         rlog.info("stage=ingest start run_date=%s", run_date.isoformat())

--- a/tests/test_handler_helpers.py
+++ b/tests/test_handler_helpers.py
@@ -14,6 +14,7 @@ from jobfetcher.handlers.pipeline import (
     resolve_db_url,
     resolve_deadline,
     resolve_max_workers,
+    resolve_mode,
     resolve_profile_path,
     resolve_run_date,
     resolve_run_id,
@@ -113,6 +114,19 @@ def test_resolve_run_date_defaults_to_utc_today():
 def test_resolve_run_date_raises_on_malformed_override():
     with pytest.raises(ValueError):
         resolve_run_date({"run_date": "not-a-date"})
+
+
+# --------------------------------------------------------------------------- mode (ADR-0023)
+def test_resolve_mode_default_and_reassess():
+    assert resolve_mode(None) == ""            # no event → normal pipeline
+    assert resolve_mode({}) == ""              # no mode key → normal pipeline
+    assert resolve_mode({"mode": "reassess"}) == "reassess"
+    assert resolve_mode({"mode": "  REASSESS "}) == "reassess"  # trimmed + lowercased
+
+
+def test_resolve_mode_ignores_non_string():
+    # a non-string mode is ignored (falls back to the normal pipeline), never crashes
+    assert resolve_mode({"mode": 123}) == ""
 
 
 # --------------------------------------------------------------------------- H-2 knobs

--- a/tests/test_integration_handler.py
+++ b/tests/test_integration_handler.py
@@ -333,6 +333,78 @@ def test_handler_resyncs_settings_from_config_on_every_run(repo, patched, tmp_pa
     assert out2["notify"]["surfaced"] == 0  # the higher bar changed what the user receives
 
 
+class _LlmScoring:
+    """A scripted LLM whose SCORE reply is parametrized (dissect reply fixed), so a re-run can
+    return a different score — the reassess/graduation scenario."""
+
+    def __init__(self, model: str, score: int) -> None:
+        self.config = type("C", (), {"model": model})()
+        self._model = model
+        self._score = score
+
+    def complete(self, *, system: str, user: str) -> str:  # noqa: ARG002
+        if "score" in system.lower() or self._model.endswith("pro"):
+            return json.dumps({
+                "score": self._score, "strengths": ["python"], "gaps": [],
+                "strategic_assessment": "x", "poster_type": "direct employer",
+                "legitimacy_verified": True,
+            })
+        return json.dumps({
+            "skills": [{"name": "Python", "level": "must", "evidence": "Required: Python and SQL"}],
+            "sector": "fintech", "normalized_title": "Data Engineer",
+        })
+
+
+def test_handler_reassess_mode_replays_and_graduates(repo, patched, tmp_path, monkeypatch):
+    """ADR-0023: `{"mode":"reassess"}` re-scores the already-scored postings against the current
+    profile with NO fetch, carries the old score into `previous_score`, and GRADUATES a job that
+    crosses the threshold upward — the immutable-bronze replay ("my progress changed my matches")."""
+    import jobfetcher.handlers.pipeline as pipe
+    from sqlalchemy import text as _text
+
+    _truncate(repo)
+
+    # --- initial full run @ threshold 80, jobs score 60 → scored but NOT surfaced ---
+    monkeypatch.setattr(pipe, "OpenAICompatLlmClient", lambda cfg=None, **kw: _LlmScoring(cfg.model, 60))
+    out1 = _invoke(tmp_path, threshold=80)
+    assert out1["statusCode"] == 200
+    assert out1["score"]["scored"] == 2 and out1["score"]["surfaced"] == 0  # 60 < 80
+
+    # --- reassess: the re-score now returns 90 (profile "improved"); the source EXPLODES if
+    # fetched, proving replay never re-fetches ---
+    monkeypatch.setattr(pipe, "OpenAICompatLlmClient", lambda cfg=None, **kw: _LlmScoring(cfg.model, 90))
+
+    class _ExplodingSource:
+        def fetch(self, spec, *, run_id):  # noqa: ARG002
+            raise AssertionError("reassess must not fetch!")
+            yield  # pragma: no cover — makes this a generator; body never runs in reassess
+
+    monkeypatch.setattr(pipe, "JSearchSourceAdapter", lambda: _ExplodingSource())
+
+    search_path, profile_path = _write_config(tmp_path, threshold=80)
+    os.environ["SEARCH_CONFIG_PATH"] = search_path
+    os.environ["PROFILE_PATH"] = profile_path
+    os.environ["RECIPIENT_EMAIL"] = "to@jobfetcher.test"
+    out2 = pipe.handler({"run_id": "reassess1", "run_date": RUN_DATE.isoformat(), "mode": "reassess"}, None)
+
+    assert out2["statusCode"] == 200 and out2["mode"] == "reassess"
+    r = out2["reassess"]
+    assert r["reassessed"] == 2
+    assert r["graduated"] == 2 and r["downgraded"] == 0  # both 60 → 90 crossed 80
+    assert len(r["graduations"]) == 2
+    assert {g["old_score"] for g in r["graduations"]} == {60}
+    assert {g["new_score"] for g in r["graduations"]} == {90}
+
+    # DB proof: the score row now holds 90 with previous_score 60 (the old value carried over)
+    with repo.engine.connect() as conn:
+        rows = conn.execute(_text("SELECT score, previous_score, fit_category FROM score")).all()
+    assert all(row.score == 90 and row.previous_score == 60 for row in rows)
+    assert all(row.fit_category == "strong_fit" for row in rows)
+
+    # no NEW bronze/posting rows were created (replay only re-scores; no fetch)
+    assert _count(repo, "bronze_posting") == 2 and _count(repo, "posting") == 2
+
+
 def _moto_notifier_factory():
     """Rebuild the moto-backed SesNotifier the `patched` fixture installs (same bucket/client),
     so a healthy re-invoke after an injected failure actually delivers through moto SES."""

--- a/tests/test_reassess.py
+++ b/tests/test_reassess.py
@@ -1,0 +1,131 @@
+"""Reassess/replay unit tests (LLM mocked, no DB, no fetch): re-scoring the already-scored set
+against the current profile updates `previous_score`, graduates a job that crosses the threshold
+upward, downgrades one that crosses down, isolates a scoring failure, and defers on a passed
+deadline. The critical negative: **no SourceAdapter/RawStore is ever touched** — replay must
+never re-fetch. Reuses the scorer-test builders."""
+from __future__ import annotations
+
+import json
+
+from jobfetcher.core.ingest import Deadline, reassess
+from jobfetcher.core.scorer import Scorer
+from tests.helpers import FakeLlm
+from tests.test_scorer import _dissected, _profile, _score_json
+
+
+class _FakeReassessRepo:
+    """In-memory repo for the reassess orchestration: a profile + the scored set in, the saved
+    scores (with previous_score) tracked. Only the methods reassess() touches."""
+
+    def __init__(self, profile_row, targets):
+        self._profile_row = profile_row
+        self._targets = targets
+        self.saved: dict[str, dict] = {}
+
+    def get_profile(self, user_id):
+        return self._profile_row
+
+    def get_scored_for_reassess(self):
+        return list(self._targets)
+
+    def save_score(self, *, cluster_id, score, fit_category, strengths, gaps,
+                   strategic_assessment, poster_type, legitimacy_verified, previous_score=None):
+        self.saved[cluster_id] = {
+            "score": score, "fit_category": fit_category, "previous_score": previous_score,
+        }
+        return cluster_id
+
+
+def _profile_row(threshold=60):
+    return {"profile": _profile().model_dump(), "threshold": threshold,
+            "hard_floor": 50, "near_miss_band": 10}
+
+
+def _targets():
+    # (posting_id, cluster_id, dissected, current_score, current_fit_category)
+    return [
+        ("p-grad", "c-grad", _dissected("A"), 45, "misaligned"),   # was below 60
+        ("p-drop", "c-drop", _dissected("B"), 80, "strong_fit"),   # was above 60
+        ("p-same", "c-same", _dissected("C"), 90, "strong_fit"),   # stays above
+    ]
+
+
+def _scorer_for(scores):
+    return Scorer(FakeLlm(*[_score_json(s) for s in scores]))
+
+
+def test_reassess_graduates_downgrades_and_tracks_previous_score():
+    """The core replay behavior: an improved profile re-scores the scored set — one job crosses
+    UP (graduated), one crosses DOWN, one stays; every save carries the old score into
+    previous_score. max_workers=1 so the scripted FakeLlm maps to targets in order."""
+    repo = _FakeReassessRepo(_profile_row(60), _targets())
+    # new scores in target order: p-grad 45->75 (graduate), p-drop 80->40 (downgrade), p-same 90->92
+    report = reassess(run_id="r", repo=repo, scorer=_scorer_for([75, 40, 92]), max_workers=1)
+
+    assert report["reassessed"] == 3
+    assert report["graduated"] == 1
+    assert report["downgraded"] == 1
+    assert report["unchanged"] == 1
+    assert report["failed"] == 0 and report["deferred"] == 0
+
+    # previous_score carries the OLD score on every re-score
+    assert repo.saved["c-grad"] == {"score": 75, "fit_category": "strong_fit", "previous_score": 45}
+    assert repo.saved["c-drop"]["previous_score"] == 80
+    assert repo.saved["c-same"]["previous_score"] == 90
+
+    # the graduation is reported with the old->new delta
+    grads = report["graduations"]
+    assert len(grads) == 1
+    assert grads[0]["posting_id"] == "p-grad"
+    assert grads[0]["old_score"] == 45 and grads[0]["new_score"] == 75
+    assert grads[0]["new_category"] == "strong_fit"
+
+
+def test_reassess_never_fetches():
+    """The replay guarantee (ADR-0023): reassess must touch NO source/raw-store — a repo that
+    only exposes the reassess methods is sufficient. If reassess tried to fetch, it would need
+    a SourceAdapter/RawStore it was never given, and this would fail loudly."""
+    repo = _FakeReassessRepo(_profile_row(60), _targets()[:1])
+    report = reassess(run_id="r", repo=repo, scorer=_scorer_for([70]), max_workers=1)
+    assert report["reassessed"] == 1
+    # no fetch-related attribute was ever needed on the repo
+    assert not hasattr(repo, "upsert_bronze") and not hasattr(repo, "get_gold_candidates")
+
+
+def test_reassess_isolates_a_scoring_failure():
+    # negative: one un-scorable posting is skipped (failed), the rest still reassess
+    class _OneBoom:
+        def __init__(self):
+            self._n = 0
+
+        def score(self, dissected, profile):
+            self._n += 1
+            from jobfetcher.core.models import ScoreResult
+            from jobfetcher.core.scorer import ScorerError
+            if self._n == 2:
+                raise ScorerError("boom")
+            return ScoreResult.model_validate(json.loads(_score_json(75)))
+
+    repo = _FakeReassessRepo(_profile_row(60), _targets())
+    report = reassess(run_id="r", repo=repo, scorer=_OneBoom(), max_workers=1)
+    assert report["failed"] == 1
+    assert report["reassessed"] == 2  # the other two still went through
+
+
+def test_reassess_defers_on_expired_deadline():
+    # negative: an expired deadline → nothing re-scored, nothing saved, all deferred
+    class _CountingScorer:
+        calls = 0
+
+        def score(self, dissected, profile):
+            type(self).calls += 1
+            return None  # never reached
+
+    repo = _FakeReassessRepo(_profile_row(60), _targets())
+    report = reassess(run_id="r", repo=repo, scorer=_CountingScorer(), deadline=Deadline(0))
+    assert report == {
+        "reassessed": 0, "graduated": 0, "downgraded": 0, "unchanged": 0,
+        "failed": 0, "deferred": 3, "graduations": [],
+    }
+    assert _CountingScorer.calls == 0
+    assert repo.saved == {}


### PR DESCRIPTION
## Why
When your profile improves (a new skill, a finished project), jobs already in the system should be **re-evaluated** — a `stretch` last week can be a `strong_fit` today. This is the medallion's designed-in **immutable-bronze → replay**: bronze is the permanent record; silver/gold/score are pure functions over it, so re-scoring costs **zero JSearch calls** (only LLM tokens). Realizes the graduation half of the old M4, re-derived from real use (P2).

**The schema already anticipated it:** `score.previous_score` is commented *"for near-miss re-scoring"* and `save_score` already carries the old score into `previous_score` on conflict. The only gap was that scoring skips already-scored postings — this wires the replay.

## What changed
- **`{"mode":"reassess"}`** handler mode — re-scores the `status='scored'` set against the **current** profile, records `previous_score`, reports **graduations** (`old < threshold <= new`), and **skips fetch/gold/notify**. Default mode = the normal pipeline, untouched.
- `Repository.get_scored_for_reassess()` + `core.ingest.reassess()` (mirrors `score_gold`: ThreadPool concurrency + deadline guard + H-1 failure isolation) + a pure `resolve_mode`. Shared profile/knobs load factored into `_load_profile_and_knobs`.
- **Flow (builds on ADR-0022):** edit `profile.local.yml` → `push_config.py` → invoke `{"mode":"reassess"}`.

## Validation
- **Unit:** graduate/downgrade/unchanged classification + `previous_score` tracking · **no-fetch guarantee** · failure isolation · deadline defer · `resolve_mode` (+ negatives). **249 unit green, ruff clean.**
- **Integration (CI Postgres + moto):** a full run scores jobs at 60 (below an 80 bar), then `reassess` re-scores them to 90 → **both graduate**, `previous_score=60`/`score=90` in the DB, no new bronze/posting rows, and the **SourceAdapter explodes if fetched** — proving replay never re-fetches.

## Scope (per ADR-0023)
Only the `scored` set is re-scored (a skill change doesn't alter gold membership — correct by design). **Deferred:** the "what graduated" **email** (rides the email-UX unit); the **query/filter** surface (next capability — export to SQLite/CSV); a `score_history` table for time-series.

Ships as **v0.4.0** (a migration). Single PR off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a reassess mode that re-scores previously evaluated jobs using the latest profile settings.
  * Reassessment now works without fetching jobs again and can surface jobs that newly qualify as the profile improves.
  * Results now include a summary of outcomes, including newly upgraded jobs and score changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->