### PR TITLE
feat(query): export DB to filterable SQLite/CSV — filter/search/organize, no custom UI (ADR-0024)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ Thumbs.db
 /tmp/
 scratch/
 probe_output/
+
+# Query/filter snapshots (ADR-0024) — generated, may hold real profile data; never commit.
+export/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@ The ***why*** behind every entry is the [session decision journal](docs/01-sessi
 
 ## [Unreleased]
 
-*Next migration candidate (P2): the **query/filter access** surface (export to SQLite/CSV → Datasette/Excel), then the **digest email UX** (poor format · apply-links must be visible).*
+*Next migration candidate (P2): the **digest email UX** (poor format · apply-links must be visible).*
+
+## [v0.5.0] — 2026-07-06 — query / filter access (export → open in a generic tool)
+
+### Added
+- **[ADR-0024] `scripts/export.py`** — snapshot the operational DB to a portable **SQLite + CSV** (gitignored `export/`) you filter/search/sort/organize in a purpose-built tool (**Datasette** recommended — faceted filters + full-text search; or DB Browser / Excel / raw `sqlite3`) — no custom UI. The star is a flat **`jobs`** table (one filterable row per posting: role · geo · skills-as-text · status · `score`/`previous_score`/`fit_category` · apply_url · dates), plus `bronze` (full fetch history), `runs`, and `profile_current`. It also **prints a summary** (totals · fit-category counts · graduations · top-5). Datasette is an optional `[query]` extra (no runtime dep); SQLite is stdlib. Docs: [querying.md](docs/querying.md).
 
 ## [v0.4.0] — 2026-07-06 — reassess / replay (re-score on an updated profile, no re-fetch)
 

--- a/docs/adr/0024-query-via-export.md
+++ b/docs/adr/0024-query-via-export.md
@@ -1,0 +1,32 @@
+# ADR-0024 — Query / filter via export-to-SQLite (not a custom UI)
+
+**Status:** Accepted
+**Date:** 2026-07-06
+
+## Context
+
+Tarig wants to **filter, search, and organize** the saved records — all runs, the bronze/silver history, and every score (including the reassess before→after). The data is **SQL-shaped and small** (one user, a few hundred rows). The question is *how to expose it* for casual ad-hoc filtering without over-building.
+
+## Decision
+
+Ship **`scripts/export.py`** — a read-only snapshot of the operational DB into **SQLite + CSV** (a gitignored `export/` dir) — and let the user filter/search/sort in a **purpose-built generic tool**, not a UI we build.
+
+- The star is a **flat `jobs` table** (`posting LEFT JOIN score ON cluster_id LEFT JOIN cluster LEFT JOIN bronze_posting`), one filterable row per posting: role (title/company/seniority/sector), geo (country/city/state), skills (searchable text + raw JSON), status, scoring (`score`/`previous_score`/`fit_category`/…), apply_url, dates. Supporting tables: `bronze` (the full fetch history, no raw blob), `runs`, `profile_current`.
+- The script also **prints a summary** (totals, fit-category counts, graduations, top-5) — instant value with no tool.
+- **Recommended viewer: Datasette** (`pip install -e '.[query]' && datasette export/jobs.sqlite`) — faceted filters, full-text search, sortable columns, a SQL box. Also fine: DB Browser for SQLite (GUI), Excel/Sheets (the CSV), or raw `sqlite3`.
+
+## Alternatives considered
+
+- **A custom filter UI / filter-flag CLI.** Rejected: reinvents what SQL tools already do superbly — an endless stream of "add a filter for X" flags/widgets. The value is *the data in a filterable form*, not bespoke filtering code.
+- **A hosted web dashboard.** Rejected *for now*: auth + hosting + a frontend is a large build. It's the eventual **end-state**, and it would read the same store — this export is the seam to it.
+- **Live-query Aurora from a GUI.** Rejected: the operational DB is the **Aurora Data API** (HTTP, not a standard Postgres wire connection) and it **scale-to-0 auto-pauses** — a GUI pointed at it is awkward, resume-laggy, and hits the live DB. A local snapshot is faster, offline, and safe to slice however.
+- **Direct SQL only (document how to run queries via the Data API).** Rejected as the *primary* answer: too technical for casual "organize"; but it's still available (`sqlite3` / Datasette's SQL box) for power users.
+
+## Consequences
+
+- Unlimited **filter / search / sort / facet** for free, offline, no Aurora-resume lag; re-run `export.py` to refresh (the snapshot is **point-in-time**).
+- No runtime dependency added (Datasette is an *optional* `[query]` extra; SQLite is stdlib).
+- The snapshot may contain the real profile / job data → `export/` is gitignored, never committed.
+- **Follow-ons (noted):** a `score_history` append table for full time-series ("45→62→78"), and a per-run **input snapshot** (which profile/config produced each score) to fully "search previous inputs" — both small schema adds; today's export covers the full *results* history + the current profile. A hosted **dashboard** remains the end-state.
+
+Full reasoning: [journal](../01-session-decision-journal.md) · plan §42. Related: [ADR-0018](0018-persistence-sqlalchemy-data-api-repository.md) (the DB), [ADR-0023](0023-reassess-replay.md) (the `previous_score` history this surfaces).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -29,5 +29,6 @@ These are the **foundational** decisions made during the design session — the 
 | [0021](0021-m1-pipeline-hardening.md) | M1 pipeline hardening: LLM retry+jitter & symmetric isolation · in-Lambda concurrency + deadline guard · subset-title gold filter + selectable LLM filter | Accepted · ✅ Validated live (v0.2.0) |
 | [0022](0022-runtime-config-in-s3.md) | Runtime config in S3 (not bundled): the Lambda reads the search spec + profile from S3 each run → change settings via `push_config.py`, no redeploy | Accepted |
 | [0023](0023-reassess-replay.md) | Reassess/replay: a `{"mode":"reassess"}` re-scores existing jobs against the updated profile with **no re-fetch** (immutable-bronze replay) → jobs graduate as skills grow | Accepted |
+| [0024](0024-query-via-export.md) | Query/filter via `scripts/export.py` → SQLite/CSV opened in Datasette/DB-Browser/Excel (not a custom UI) — filter/search/organize for free | Accepted |
 
 > Full reasoning narrative: [01-session-decision-journal](../01-session-decision-journal.md). Crisp decision list: [ledgers/decisions-locked](../ledgers/decisions-locked.md).

--- a/docs/querying.md
+++ b/docs/querying.md
@@ -1,0 +1,49 @@
+# Querying your records — filter, search, organize
+
+Your job history lives in the operational DB (Aurora). To **filter / search / sort / organize** it,
+export a portable snapshot and open it in a tool built for exactly that ([ADR-0024](adr/0024-query-via-export.md)) —
+no custom UI, full "basic operations" for free, offline.
+
+## 1. Export a snapshot
+
+```bash
+python scripts/export.py
+```
+
+This reads the DB (Aurora resumes from idle — a few seconds) and writes, into a gitignored `export/`:
+
+- **`export/jobs.sqlite`** — the snapshot (primary), and
+- **`export/jobs.csv`** — the flat `jobs` table (for spreadsheets).
+
+It also prints a **summary** (totals · fit-category counts · graduations · top-5) so you get a quick
+read without opening anything. Re-run it any time to refresh (it's a point-in-time snapshot).
+
+*(DB connection: it uses `$JOBFETCHER_DB_URL` if set, otherwise the deployed Aurora via `terraform output`.)*
+
+## 2. Open it and filter
+
+**Datasette (recommended)** — a browser UI with faceted filters, full-text search, sortable columns, and a SQL box:
+
+```bash
+pip install -e '.[query]'      # one-time; Datasette is an optional extra, not a runtime dep
+datasette export/jobs.sqlite   # opens http://localhost:8001
+```
+
+Other options: **DB Browser for SQLite** (desktop GUI → Browse Data → filter/sort per column) · **Excel / Google Sheets** (open `jobs.csv`, AutoFilter) · **raw SQL** (`sqlite3 export/jobs.sqlite`).
+
+## What's in the snapshot
+
+- **`jobs`** — one row per posting (the table you filter): `posting_id`, `run_id`, `status` (silver/gold_candidate/scored), `normalized_title`, `raw_title`, `company`, `seniority`, `sector`, `employment_type`, `country`/`city`/`state`/`location`, `skills` (text) + `skills_json`, `score`, `previous_score`, `fit_category` (strong_fit/near_miss/stretch/misaligned), `poster_type`, `legitimacy_verified`, `strengths`, `gaps`, `apply_url`, `scored_at`, `fetched_at`, `posting_count`.
+- **`bronze`** — the full fetch history (ids, source, run_id, S3 key, fetched_at; the raw JSON stays in S3).
+- **`runs`** — the digest send log · **`profile_current`** — your current profile + thresholds.
+
+## Example filters
+
+| Goal | SQL (Datasette SQL box / `sqlite3`) |
+|---|---|
+| All strong fits in Saudi | `SELECT * FROM jobs WHERE fit_category='strong_fit' AND country='sa' ORDER BY score DESC` |
+| Jobs that **graduated** on the last reassess | `SELECT normalized_title, company, previous_score, score FROM jobs WHERE previous_score < 60 AND score >= 60` |
+| "Architect" roles scoring 50–70 | `SELECT * FROM jobs WHERE normalized_title LIKE '%Architect%' AND score BETWEEN 50 AND 70` |
+| Everything from one run | `SELECT * FROM jobs WHERE run_id = '<run_id>'` |
+
+In Datasette you can do all of these by clicking facets (country, fit_category, status) and typing in the search box — no SQL needed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,9 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = ["pytest>=7", "pytest-cov>=4", "ruff>=0.4", "testcontainers[postgres]>=4", "moto[s3]>=5"]
+# Not a runtime dep — the recommended viewer for the `scripts/export.py` snapshot (ADR-0024):
+#   pip install -e '.[query]' && datasette export/jobs.sqlite
+query = ["datasette>=1"]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/scripts/export.py
+++ b/scripts/export.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""export.py — snapshot the operational DB to a portable SQLite + CSV you can filter/search/
+organize in a generic tool (ADR-0024). The data is SQL-shaped + tiny, so rather than a custom
+filter UI we export and open in a purpose-built viewer:
+
+    python scripts/export.py                 # -> export/jobs.sqlite + export/jobs.csv + a summary
+    datasette export/jobs.sqlite             # faceted filter/search/sort in a browser (recommended)
+    # or open export/jobs.csv in Excel/Sheets, or `sqlite3 export/jobs.sqlite`
+
+The star is a flat `jobs` table (one filterable row per posting: role · geo · skills · status ·
+score/previous_score/fit_category · apply_url · dates), plus `bronze` (the full fetch history),
+`runs`, and the current `profile`. Read-only; a point-in-time snapshot — re-run to refresh.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from jobfetcher.db.engine import make_engine  # noqa: E402
+from jobfetcher.handlers.pipeline import resolve_db_url  # noqa: E402 (reuse the URL builder)
+
+# ── the flat `jobs` table: posting ⨝ score ⨝ cluster ⨝ bronze (LEFT so un-scored silver shows) ──
+_JOBS_SQL = """
+SELECT
+  p.posting_id, p.source, b.run_id, p.status,
+  p.normalized_title, p.title AS raw_title, p.company, p.seniority, p.sector, p.employment_type,
+  p.country, p.city, p.state, p.location,
+  p.skills,
+  s.score, s.previous_score, s.fit_category, s.poster_type, s.legitimacy_verified, s.scored_at,
+  s.strengths, s.gaps, s.strategic_assessment,
+  p.apply_url, p.fetched_at, c.posting_count
+FROM posting p
+LEFT JOIN score s ON p.cluster_id = s.cluster_id
+LEFT JOIN cluster c ON p.cluster_id = c.cluster_id
+LEFT JOIN bronze_posting b ON p.bronze_id = b.bronze_id
+ORDER BY s.score DESC NULLS LAST, p.posting_id
+"""
+
+# no raw_payload — it's large + already in S3; this is the fetch-history index
+_BRONZE_SQL = "SELECT bronze_id, source, source_job_id, run_id, s3_raw_key, fetched_at FROM bronze_posting ORDER BY fetched_at"
+_RUNS_SQL = "SELECT run_date, user_id, run_id FROM run_log ORDER BY run_date"
+_PROFILE_SQL = "SELECT user_id, threshold, hard_floor, near_miss_band, profile FROM profile"
+
+
+# --------------------------------------------------------------------------- transforms (pure)
+def _as_list(value: Any) -> list:
+    """A JSONB column arrives as a Python list (local psycopg2) OR a JSON string (Data API) OR
+    None. Normalize to a list."""
+    if value is None:
+        return []
+    if isinstance(value, str):
+        try:
+            return json.loads(value) or []
+        except json.JSONDecodeError:
+            return []
+    return list(value)
+
+
+def skills_text(skills: Any) -> str:
+    """`[{name, level, evidence}, …]` → a comma-joined, searchable `"Python, SQL, Airflow"`."""
+    return ", ".join(str(s.get("name", "")).strip() for s in _as_list(skills) if s.get("name"))
+
+
+def list_text(items: Any) -> str:
+    """A JSON list of short phrases (strengths/gaps) → newline-joined plain text."""
+    return "\n".join(str(x).strip() for x in _as_list(items) if str(x).strip())
+
+
+def _row_to_job(row: dict) -> dict:
+    """Flatten one `jobs` row: JSONB → readable text (+ keep raw skills JSON for Datasette)."""
+    out = dict(row)
+    out["skills"] = skills_text(row.get("skills"))
+    out["skills_json"] = json.dumps(_as_list(row.get("skills")), ensure_ascii=False)
+    out["strengths"] = list_text(row.get("strengths"))
+    out["gaps"] = list_text(row.get("gaps"))
+    out["legitimacy_verified"] = _bool01(row.get("legitimacy_verified"))
+    for k, v in list(out.items()):  # timestamps/dates → ISO strings (sqlite/csv friendly)
+        if hasattr(v, "isoformat"):
+            out[k] = v.isoformat()
+    return out
+
+
+def _bool01(v: Any) -> Any:
+    return None if v is None else (1 if v else 0)
+
+
+# --------------------------------------------------------------------------- sqlite/csv writer
+def write_snapshot(
+    *, jobs: list[dict], bronze: list[dict], runs: list[dict], profile: list[dict], out_dir: Path
+) -> tuple[Path, Path]:
+    """Write `jobs.sqlite` (jobs + bronze + runs + profile_current) and `jobs.csv` (the flat jobs
+    table). Pure over in-memory lists (unit-testable, no DB)."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    sqlite_path = out_dir / "jobs.sqlite"
+    csv_path = out_dir / "jobs.csv"
+
+    if sqlite_path.exists():
+        sqlite_path.unlink()  # a fresh snapshot each run
+    conn = sqlite3.connect(sqlite_path)
+    try:
+        _write_table(conn, "jobs", jobs)
+        _write_table(conn, "bronze", bronze)
+        _write_table(conn, "runs", runs)
+        _write_table(conn, "profile_current", profile)
+        conn.commit()
+    finally:
+        conn.close()
+
+    # the flat jobs table as CSV (Excel/Sheets)
+    if jobs:
+        cols = list(jobs[0].keys())
+        with csv_path.open("w", newline="", encoding="utf-8") as f:
+            w = csv.DictWriter(f, fieldnames=cols)
+            w.writeheader()
+            w.writerows(jobs)
+    else:
+        csv_path.write_text("", encoding="utf-8")
+    return sqlite_path, csv_path
+
+
+def _write_table(conn: sqlite3.Connection, name: str, rows: list[dict]) -> None:
+    if not rows:
+        conn.execute(f'CREATE TABLE "{name}" (_empty TEXT)')
+        return
+    cols = list(rows[0].keys())
+    col_defs = ", ".join(f'"{c}"' for c in cols)
+    conn.execute(f'CREATE TABLE "{name}" ({col_defs})')
+    placeholders = ", ".join("?" for _ in cols)
+    conn.executemany(
+        f'INSERT INTO "{name}" VALUES ({placeholders})',
+        [[r.get(c) for c in cols] for r in rows],
+    )
+
+
+# --------------------------------------------------------------------------- DB read
+def _fetch(engine, sql: str) -> list[dict]:
+    from sqlalchemy import text
+
+    for attempt in range(6):  # Aurora scale-to-0 resumes on a cold call → retry a few times
+        try:
+            with engine.connect() as conn:
+                return [dict(r) for r in conn.execute(text(sql)).mappings().all()]
+        except Exception as exc:  # noqa: BLE001
+            if "resuming" in str(exc).lower() and attempt < 5:
+                time.sleep(8)
+                continue
+            raise
+    return []
+
+
+def read_data(engine) -> dict[str, list[dict]]:
+    jobs = [_row_to_job(r) for r in _fetch(engine, _JOBS_SQL)]
+    bronze = [_iso_row(r) for r in _fetch(engine, _BRONZE_SQL)]
+    runs = [_iso_row(r) for r in _fetch(engine, _RUNS_SQL)]
+    profile = [_profile_row(r) for r in _fetch(engine, _PROFILE_SQL)]
+    return {"jobs": jobs, "bronze": bronze, "runs": runs, "profile": profile}
+
+
+def _iso_row(row: dict) -> dict:
+    return {k: (v.isoformat() if hasattr(v, "isoformat") else v) for k, v in row.items()}
+
+
+def _profile_row(row: dict) -> dict:
+    out = _iso_row(row)
+    if "profile" in out:  # the JSONB profile blob → a compact JSON string
+        out["profile"] = json.dumps(
+            out["profile"] if isinstance(out["profile"], (dict, list)) else _as_list(out["profile"]),
+            ensure_ascii=False,
+        )
+    return out
+
+
+# --------------------------------------------------------------------------- summary (terminal)
+def print_summary(data: dict[str, list[dict]]) -> None:
+    jobs = data["jobs"]
+    scored = [j for j in jobs if j.get("score") is not None]
+    thr = (data["profile"][0]["threshold"] if data["profile"] and data["profile"][0].get("threshold")
+           is not None else 60)
+    cats: dict[str, int] = {}
+    for j in scored:
+        cats[j.get("fit_category") or "?"] = cats.get(j.get("fit_category") or "?", 0) + 1
+    grads = [j for j in scored if j.get("previous_score") is not None
+             and j["previous_score"] < thr <= (j.get("score") or 0)]
+    print(f"\n  Snapshot: {len(data['bronze'])} bronze · {len(jobs)} silver · {len(scored)} scored"
+          f" · threshold {thr}")
+    print(f"  Fit categories: {cats}")
+    print(f"  Graduated (prev < {thr} <= score): {len(grads)}")
+    print("  Top 5 by score:")
+    for j in scored[:5]:
+        print(f"    [{j.get('score')}] {j.get('normalized_title')} @ {j.get('company')} "
+              f"({j.get('country')})")
+
+
+# --------------------------------------------------------------------------- db url + main
+def _resolve_db_url() -> str:
+    explicit = os.environ.get("JOBFETCHER_DB_URL")
+    if explicit and explicit.strip():
+        return explicit.strip()
+    env = dict(os.environ)
+    env.setdefault("DB_CLUSTER_ARN", _tf_output("aurora_cluster_arn"))
+    env.setdefault("DB_SECRET_ARN", _tf_output("db_master_secret_arn"))
+    env.setdefault("DB_NAME", os.environ.get("DB_NAME", "jobfetcher"))
+    return resolve_db_url(env)  # reuse the handler's URL builder (the aurora_cluster_arn param, etc.)
+
+
+def _tf_output(name: str) -> str:
+    try:
+        out = subprocess.run(
+            ["terraform", f"-chdir={ROOT / 'terraform'}", "output", "-raw", name],
+            capture_output=True, text=True, timeout=30, check=True,
+        )
+        return out.stdout.strip()
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Export the DB to a filterable SQLite + CSV snapshot.")
+    ap.add_argument("--out", default=str(ROOT / "export"), help="output dir (default: export/)")
+    args = ap.parse_args()
+
+    engine = make_engine(_resolve_db_url())
+    print("reading the operational DB (Aurora may resume from idle — a few seconds)…")
+    data = read_data(engine)
+    sqlite_path, csv_path = write_snapshot(
+        jobs=data["jobs"], bronze=data["bronze"], runs=data["runs"], profile=data["profile"],
+        out_dir=Path(args.out),
+    )
+    print_summary(data)
+    print(f"\n  wrote {sqlite_path}  +  {csv_path}")
+    print(f"  filter/search it:  datasette {sqlite_path}   (or open the CSV in Excel/Sheets)")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,0 +1,91 @@
+"""Unit tests for the export snapshot (no DB): the JSONB→text transforms (robust to both a
+Python list and a JSON string, as the local psycopg2 vs Aurora Data API dialects return) and
+the SQLite/CSV writer (given in-memory rows → the four tables + the flat CSV). The DB read is
+covered by the integration test."""
+from __future__ import annotations
+
+import importlib.util
+import sqlite3
+from pathlib import Path
+
+# load the standalone script as a module
+_spec = importlib.util.spec_from_file_location(
+    "export", Path(__file__).resolve().parents[1] / "scripts" / "export.py"
+)
+export = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(export)
+
+
+# --------------------------------------------------------------------------- transforms
+def test_skills_text_from_list_and_json_string():
+    # local psycopg2 returns a list; the Aurora Data API returns a JSON string — both → text
+    as_list = [{"name": "Python", "level": "must"}, {"name": "SQL"}, {"name": ""}]
+    assert export.skills_text(as_list) == "Python, SQL"
+    assert export.skills_text('[{"name": "Airflow"}]') == "Airflow"
+    assert export.skills_text(None) == ""
+
+
+def test_list_text_and_bool01():
+    assert export.list_text(["strong python", "fintech bg"]) == "strong python\nfintech bg"
+    assert export.list_text('["a", "b"]') == "a\nb"
+    assert export.list_text(None) == ""
+    assert export._bool01(True) == 1 and export._bool01(False) == 0 and export._bool01(None) is None
+
+
+def test_as_list_handles_garbage_string():
+    # a non-JSON string must not crash the export — it degrades to []
+    assert export._as_list("not json") == []
+
+
+def test_row_to_job_flattens_jsonb_and_timestamps():
+    from datetime import datetime, timezone
+
+    row = {
+        "posting_id": "p1", "score": 85, "previous_score": 45, "fit_category": "strong_fit",
+        "skills": [{"name": "Python"}, {"name": "SQL"}],
+        "strengths": ["strong python"], "gaps": ["no spark"],
+        "legitimacy_verified": True,
+        "scored_at": datetime(2026, 7, 6, 12, 0, tzinfo=timezone.utc),
+    }
+    job = export._row_to_job(row)
+    assert job["skills"] == "Python, SQL"
+    assert '"name": "Python"' in job["skills_json"]  # raw JSON kept for Datasette
+    assert job["strengths"] == "strong python" and job["gaps"] == "no spark"
+    assert job["legitimacy_verified"] == 1
+    assert job["scored_at"] == "2026-07-06T12:00:00+00:00"  # timestamp → ISO string
+
+
+# --------------------------------------------------------------------------- writer
+def test_write_snapshot_creates_all_tables_and_csv(tmp_path):
+    jobs = [
+        {"posting_id": "p1", "normalized_title": "Data Engineer", "company": "Acme",
+         "country": "sa", "status": "scored", "score": 85, "previous_score": 45,
+         "fit_category": "strong_fit", "skills": "Python, SQL", "apply_url": "http://x"},
+        {"posting_id": "p2", "normalized_title": "Data Architect", "company": "Beta",
+         "country": "ae", "status": "silver", "score": None, "previous_score": None,
+         "fit_category": None, "skills": "", "apply_url": "http://y"},
+    ]
+    sp, cp = export.write_snapshot(
+        jobs=jobs,
+        bronze=[{"bronze_id": "b1", "run_id": "r1"}],
+        runs=[{"run_date": "2026-07-06", "run_id": "r1"}],
+        profile=[{"user_id": "default", "threshold": 60, "profile": "{}"}],
+        out_dir=tmp_path,
+    )
+    con = sqlite3.connect(sp)
+    tables = {r[0] for r in con.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    assert {"jobs", "bronze", "runs", "profile_current"} <= tables
+    rows = con.execute("SELECT posting_id, score, fit_category FROM jobs ORDER BY posting_id").fetchall()
+    assert rows == [("p1", 85, "strong_fit"), ("p2", None, None)]  # scored + un-scored silver both present
+    # the flat CSV exists + has a header + both rows
+    text = cp.read_text(encoding="utf-8")
+    assert "posting_id" in text.splitlines()[0]
+    assert len(text.strip().splitlines()) == 3  # header + 2 jobs
+
+
+def test_write_snapshot_empty_is_safe(tmp_path):
+    # negative: an empty DB must not crash — the tables exist, the CSV is empty
+    sp, cp = export.write_snapshot(jobs=[], bronze=[], runs=[], profile=[], out_dir=tmp_path)
+    assert sp.exists() and cp.exists()
+    con = sqlite3.connect(sp)
+    assert con.execute("SELECT count(*) FROM jobs").fetchone()[0] == 0

--- a/tests/test_integration_handler.py
+++ b/tests/test_integration_handler.py
@@ -434,7 +434,11 @@ def test_export_snapshot_from_db(repo, patched, tmp_path):
     )
     con = sqlite3.connect(sp)
     assert con.execute("SELECT count(*) FROM jobs WHERE score >= 60").fetchone()[0] == 2
-    assert cp.read_text(encoding="utf-8").strip().count("\n") == 2  # header + 2 rows
+    # count CSV rows via the parser (fields like strengths carry embedded newlines)
+    import csv as _csv
+    with cp.open(encoding="utf-8", newline="") as f:
+        csv_rows = list(_csv.reader(f))
+    assert len(csv_rows) == 3  # header + 2 jobs
 
 
 def _moto_notifier_factory():

--- a/tests/test_integration_handler.py
+++ b/tests/test_integration_handler.py
@@ -405,6 +405,38 @@ def test_handler_reassess_mode_replays_and_graduates(repo, patched, tmp_path, mo
     assert _count(repo, "bronze_posting") == 2 and _count(repo, "posting") == 2
 
 
+def test_export_snapshot_from_db(repo, patched, tmp_path):
+    """ADR-0024: `scripts/export.py`'s DB read + snapshot over a REAL DB. Run a pipeline to
+    create scored rows, then export → the flat `jobs` table (in sqlite + csv) carries them with
+    score/fit_category, and `bronze`/`runs` are populated. Proves the SQL joins match the schema."""
+    import importlib.util
+    import sqlite3
+
+    _spec = importlib.util.spec_from_file_location(
+        "export", Path(__file__).resolve().parents[1] / "scripts" / "export.py"
+    )
+    export = importlib.util.module_from_spec(_spec)
+    _spec.loader.exec_module(export)
+
+    _truncate(repo)
+    out = _invoke(tmp_path)  # full pipeline → 2 scored postings (score 90)
+    assert out["statusCode"] == 200 and out["score"]["scored"] == 2
+
+    data = export.read_data(repo.engine)  # the real SELECTs against the seeded schema
+    assert len(data["jobs"]) == 2
+    assert all(j["score"] == 90 and j["fit_category"] == "strong_fit" for j in data["jobs"])
+    assert data["jobs"][0]["skills"]  # JSONB skills flattened to searchable text
+    assert len(data["bronze"]) == 2 and len(data["runs"]) == 1
+
+    sp, cp = export.write_snapshot(
+        jobs=data["jobs"], bronze=data["bronze"], runs=data["runs"], profile=data["profile"],
+        out_dir=tmp_path / "export",
+    )
+    con = sqlite3.connect(sp)
+    assert con.execute("SELECT count(*) FROM jobs WHERE score >= 60").fetchone()[0] == 2
+    assert cp.read_text(encoding="utf-8").strip().count("\n") == 2  # header + 2 rows
+
+
 def _moto_notifier_factory():
     """Rebuild the moto-backed SesNotifier the `patched` fixture installs (same bucket/client),
     so a healthy re-invoke after an injected failure actually delivers through moto SES."""


### PR DESCRIPTION
## Why
You wanted to **filter, search, and organize** the saved records. The data is SQL-shaped + tiny (one user, a few hundred rows), so a custom filter UI would reinvent what SQL tools already do superbly. Instead: **export a snapshot → open in a purpose-built viewer.** Full filtering for free, offline, no Aurora-resume lag.

## What changed
- **`scripts/export.py`** — read-only snapshot of the DB into **SQLite + CSV** (gitignored `export/`). The star is a flat **`jobs`** table (one filterable row per posting: role · geo · skills-as-text · status · `score`/`previous_score`/`fit_category` · apply_url · dates), plus `bronze` (full fetch history), `runs`, `profile_current`. It also **prints a summary** (totals · fit-category counts · graduations · top-5).
- **Open it in:** Datasette (recommended — faceted filters + full-text search), DB Browser for SQLite, Excel/Sheets (the CSV), or raw `sqlite3`. Datasette is an optional `[query]` extra (no runtime dep); SQLite is stdlib.
- **Docs:** [docs/querying.md](docs/querying.md) — the workflow + example filters ("all strong fits in Saudi", "jobs that graduated last reassess", "everything from run X").

## Validation
- **Unit:** the JSONB→text transforms (robust to both a Python list *and* a JSON string — the local-psycopg2 vs Aurora-Data-API dialects — plus a garbage-string degrade) + the SQLite/CSV writer (→ 4 tables + the flat CSV; empty-DB safe). **255 unit green, ruff clean.**
- **Integration (CI Postgres):** run a pipeline → export over the real seeded DB → the `jobs` table carries the scored rows (score/fit_category), `bronze`/`runs` populated — validates the SQL joins against the live schema.

## Scope (per ADR-0024)
A hosted **dashboard** is the eventual end-state (not this). Noted follow-ons: a `score_history` table (time-series) + a per-run input snapshot (which profile produced which score). Ships as **v0.5.0**.

Next: the **digest email UX** (v0.6.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an export workflow that creates portable SQLite and CSV snapshots for offline querying, filtering, and sorting.
  * Included a summary output after export with key counts and top results.

* **Documentation**
  * Added guidance for using exported data with common tools and updated release notes for the new workflow.

* **Tests**
  * Added coverage for snapshot generation, data formatting, and end-to-end export behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->