### PR TITLE
feat(digest): reachable full job list — presigned S3 report link (B-1)

### DIFF
--- a/scripts/preview_digest.py
+++ b/scripts/preview_digest.py
@@ -5,7 +5,10 @@
 
 The sample exercises every branch of the truthful digest: a genuinely-new match, a
 **graduation** (green `↑ 55→72` badge), a **collapsed dup group** (seen 3× — scores 75–88),
-the no-apply-link state, and the compact **still-open** section (already-surfaced matches).
+the no-apply-link state, and the compact **still-open** section (already-surfaced matches). It
+also passes a sample `full_list_url` so the **linked state** (B-1) of the below-threshold footer
+and the "…and N more" overflow renders, and writes the full-list report page itself to
+`export/full_list_preview.html`.
 
     python scripts/preview_digest.py    # -> export/digest_preview.html (open it in a browser)
 """
@@ -20,6 +23,11 @@ sys.path.insert(0, str(ROOT / "src"))
 
 from jobfetcher.core.notifier import render_digest  # noqa: E402
 from jobfetcher.core.ports import ShortlistItem  # noqa: E402
+from jobfetcher.core.report import render_full_list  # noqa: E402
+
+# A sample presigned-style link (https so it passes the notifier's scheme allowlist) — the
+# real one is minted per run by S3ReportStore.presign; here it just shows the linked state.
+_FULL_LIST_URL = "https://jobfetcher-data.example.com/reports/2026-07-10/jobs-preview.html?sig=demo"
 
 # When the "last digest" went out — the new/still-open split compares each item's scored_at
 # to this: a judgment written AFTER it (fresh) can be news; anything older is still-open.
@@ -103,15 +111,34 @@ def main() -> None:
     # grouping/ordering assumes that input invariant, so the preview honors it too.
     items = sorted(_SAMPLE, key=lambda i: i.score, reverse=True)
     subject, html, text = render_digest(
-        items, below_count=17, threshold=60, date=date.today(), since=_SINCE
+        items, below_count=17, threshold=60, date=date.today(), since=_SINCE,
+        full_list_url=_FULL_LIST_URL,
+    )
+    # The full-list report page itself: reuse the same sample + a few synthetic below-threshold
+    # rows so the "show below-threshold" filter has something to hide/show.
+    below_sample = [
+        ShortlistItem(
+            posting_id=f"below-{i}", title=f"Junior Role {i}", company=f"SmallCo {i}",
+            apply_url=f"https://jobs.example.com/apply/below-{i}",
+            normalized_title="Data Analyst", score=score, fit_category="near_miss",
+            strengths=["SQL basics"], gaps=["needs more platform depth"],
+            city="Riyadh", country="sa", scored_at=_FRESH,
+        )
+        for i, score in enumerate((55, 48, 40))
+    ]
+    full_list_html = render_full_list(
+        sorted(items + below_sample, key=lambda i: i.score, reverse=True),
+        threshold=60, run_date=date.today(), generated_at=datetime.now(timezone.utc),
     )
     out = ROOT / "export"
     out.mkdir(parents=True, exist_ok=True)
     (out / "digest_preview.html").write_text(html, encoding="utf-8")
     (out / "digest_preview.txt").write_text(text, encoding="utf-8")
+    (out / "full_list_preview.html").write_text(full_list_html, encoding="utf-8")
     print(f"subject: {subject}")
     print(f"wrote {out / 'digest_preview.html'}  (open it in a browser)")
     print(f"wrote {out / 'digest_preview.txt'}")
+    print(f"wrote {out / 'full_list_preview.html'}  (the full-list report page)")
 
 
 if __name__ == "__main__":

--- a/src/jobfetcher/adapters/repository_postgres.py
+++ b/src/jobfetcher/adapters/repository_postgres.py
@@ -666,6 +666,93 @@ class PostgresRepository:
                 below += 1
         return surfaced, below
 
+    def get_all_scored(
+        self, *, max_age_days: int | None = None
+    ) -> list[ShortlistItem]:
+        # The full-list report input (B-1): the SAME score↔posting↔bronze join as
+        # get_scored_shortlist, but WITHOUT the threshold cut — every scored posting (surfaced
+        # AND below) is returned, score DESC (posting_id tiebreak for a stable page). Two extra
+        # columns vs the shortlist: `score.score_override` (the human correction) and the latest
+        # application-outcome status via a correlated newest-row subquery on `application_event`
+        # (the `scripts/export.py` "latest status" shape, as a scalar subselect — Data-API-safe:
+        # a plain SELECT, no LATERAL). The `max_age_days` age bound is byte-for-byte the shortlist
+        # rule (unknown age INCLUDED; a bound parameter, never interpolated SQL).
+        s, p, b, ae = (
+            tables.score, tables.posting, tables.bronze_posting, tables.application_event
+        )
+        age_source = func.coalesce(p.c.fetched_at, b.c.fetched_at)
+        latest_status = (
+            select(ae.c.status)
+            .where(ae.c.posting_id == p.c.posting_id)
+            .order_by(ae.c.noted_at.desc(), ae.c.event_id.desc())
+            .limit(1)
+            .scalar_subquery()
+        )
+        stmt = (
+            select(
+                p.c.posting_id,
+                p.c.title,
+                p.c.company,
+                p.c.apply_url,
+                p.c.normalized_title,
+                p.c.city,
+                p.c.country,
+                p.c.fingerprint,
+                s.c.score,
+                s.c.score_override,
+                s.c.fit_category,
+                s.c.strengths,
+                s.c.gaps,
+                s.c.strategic_assessment,
+                s.c.previous_score,
+                s.c.scored_at,
+                age_source.label("effective_fetched_at"),
+                latest_status.label("application_status"),
+            )
+            .select_from(
+                s.join(p, s.c.cluster_id == p.c.cluster_id).outerjoin(
+                    b, p.c.bronze_id == b.c.bronze_id
+                )
+            )
+            .order_by(s.c.score.desc(), p.c.posting_id)
+        )
+        if max_age_days is not None and max_age_days > 0:
+            cutoff = datetime.now(timezone.utc) - timedelta(days=max_age_days)
+            stmt = stmt.where(age_source.is_(None) | (age_source >= cutoff))
+        try:
+            with self.engine.connect() as conn:
+                rows = conn.execute(stmt).mappings().all()
+        except SQLAlchemyError as e:
+            raise RepositoryError(f"get_all_scored failed: {e}") from e
+
+        out: list[ShortlistItem] = []
+        for row in rows:
+            if row["score"] is None:
+                continue  # an un-scored join artifact never reaches the report
+            out.append(
+                ShortlistItem(
+                    posting_id=row["posting_id"],
+                    title=row["title"],
+                    company=row["company"],
+                    apply_url=row["apply_url"],
+                    normalized_title=row["normalized_title"],
+                    score=row["score"],
+                    fit_category=row["fit_category"],
+                    strengths=list(row["strengths"] or []),
+                    gaps=list(row["gaps"] or []),
+                    strategic_assessment=row["strategic_assessment"],
+                    city=row["city"],
+                    country=row["country"],
+                    previous_score=row["previous_score"],
+                    fingerprint=row["fingerprint"],
+                    fetched_at=row["effective_fetched_at"],
+                    scored_at=row["scored_at"],
+                    score_override=row["score_override"],
+                    application_status=row["application_status"],
+                )
+            )
+        return out
+
     def was_digest_sent(self, *, user_id: str, run_date: date) -> bool:
         stmt = select(tables.run_log.c.run_id).where(
             (tables.run_log.c.user_id == user_id)

--- a/src/jobfetcher/adapters/s3_reports.py
+++ b/src/jobfetcher/adapters/s3_reports.py
@@ -1,0 +1,65 @@
+"""`S3ReportStore` — uploads the full-list HTML report (B-1) to S3 and mints a presigned GET URL
+so the daily digest can carry an https link to the real data. Mirrors `S3RawStore`: the bucket
+comes from `$JOBFETCHER_DATA_BUCKET` (no default — a clear error if unset), boto3 uses the ambient
+IAM identity (no secrets here), tests inject a moto/mock client.
+
+Known constraint (ACCEPTED — do not fight it): a URL signed with the Lambda role's *temporary*
+credentials is capped at the session-token TTL (hours, not days). That is fine for a daily email
+— same-day reachability; tomorrow's digest regenerates the link. The caller requests a sane
+expiry; boto3/STS caps it as needed.
+"""
+from __future__ import annotations
+
+import os
+from typing import Any, Protocol
+
+_BUCKET_ENV = "JOBFETCHER_DATA_BUCKET"
+_REPORT_CONTENT_TYPE = "text/html; charset=utf-8"
+
+
+class ReportStore(Protocol):
+    """Uploads one HTML report object and mints a presigned GET URL for it (the core depends on
+    this port, not boto3 — ADR-0015)."""
+
+    def put_report(self, *, html: str, key: str) -> None:
+        ...
+
+    def presign(self, *, key: str, expires: int) -> str:
+        ...
+
+
+class S3ReportStore:
+    """`ReportStore` over S3 (boto3 `put_object` + `generate_presigned_url`). One client, reused."""
+
+    def __init__(self, *, bucket: str | None = None, client: Any = None) -> None:
+        self._bucket = bucket or os.environ.get(_BUCKET_ENV) or ""
+        if not self._bucket.strip():
+            raise ValueError(
+                f"no S3 data bucket configured — set ${_BUCKET_ENV} or pass bucket="
+            )
+        if client is not None:
+            self._client = client
+        else:
+            import boto3  # lazy: tests inject a moto/mock client and need no real import here
+
+            self._client = boto3.client("s3")
+
+    def put_report(self, *, html: str, key: str) -> None:
+        """Write `html` to `key` as a UTF-8 `text/html` object. Unlike immutable bronze a report
+        is a **regenerated daily snapshot** — a re-run for the same date overwrites, so there is
+        no existence check."""
+        self._client.put_object(
+            Bucket=self._bucket,
+            Key=key,
+            Body=html.encode("utf-8"),
+            ContentType=_REPORT_CONTENT_TYPE,
+        )
+
+    def presign(self, *, key: str, expires: int) -> str:
+        """Return a presigned GET URL for `key`, valid for up to `expires` seconds (capped by the
+        signing credential's TTL — see the module note)."""
+        return self._client.generate_presigned_url(
+            "get_object",
+            Params={"Bucket": self._bucket, "Key": key},
+            ExpiresIn=expires,
+        )

--- a/src/jobfetcher/core/ingest.py
+++ b/src/jobfetcher/core/ingest.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import logging
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from datetime import date
+from datetime import date, datetime, timezone
 from typing import TYPE_CHECKING, Any
 
 from ..adapters.jsearch_source import QUERY_COUNTRY_KEY, jd_and_metadata_from_jsearch
@@ -22,10 +22,12 @@ from .fingerprint import fingerprint
 from .notifier import render_digest
 from .ports import FilterError, LlmError, NotifierError, RepositoryError
 from .profile import Profile
+from .report import render_full_list
 from .scorer import ScorerError, subscores_payload
 
 if TYPE_CHECKING:
     from ..adapters.s3_raw import RawStore
+    from ..adapters.s3_reports import ReportStore
     from .dissector import Dissector
     from .ports import FilterStrategy, Notifier, Repository, SourceAdapter
     from .scorer import Scorer
@@ -46,6 +48,11 @@ log = logging.getLogger(__name__)
 # LLM calls are pure I/O — this many run concurrently per stage (H-2). DB writes always stay
 # on the main thread (the Data-API dialect's thread-safety is deliberately not relied on).
 DEFAULT_MAX_WORKERS = 8
+
+# Presigned full-list-report link lifetime (B-1). A daily email only needs same-day
+# reachability; a link signed with the Lambda role's temporary creds is capped at the session
+# TTL anyway (hours) — requesting 12h is a sane ask, tomorrow's digest regenerates the link.
+_REPORT_URL_EXPIRY_S = 12 * 3600
 
 # Sentinel returned by a worker whose task started after the deadline: the item was neither
 # processed nor failed — it is deferred to the next (idempotent) run.
@@ -667,6 +674,7 @@ def notify(
     user_id: str = DEFAULT_USER_ID,
     run_date: date | None = None,
     max_age_days: int | None = None,
+    report_store: "ReportStore | None" = None,
 ) -> dict[str, int]:
     """Step-6 notification: load the profile (its **runtime** threshold) → read the scored
     shortlist (surfaced + below count) → render the daily digest → send it.
@@ -688,6 +696,11 @@ def notify(
     today" email (VG5 negative) — the digest renderer handles the empty case, not the caller
     (and a zero-NEW day sends an honest "no new matches since {date}" email).
 
+    **The full-list report link is an enhancement, NEVER a new way to fail (B-1):** when a
+    `report_store` is supplied, the whole build→upload→presign is best-effort inside a guard —
+    any failure is logged and the digest STILL sends, degraded to today's plain text (no link).
+    The email send itself stays loud, unchanged.
+
     Returns `{surfaced, below_threshold, sent}` (`sent` is 1 — a send failure raises before
     we get here)."""
     if not recipient_email:
@@ -701,11 +714,42 @@ def notify(
     # (DB row → documented default) and passes it down, so the surfaced/below split is computed
     # against the one config knob — the Repository no longer re-derives its own constant.
     since = repo.get_last_digest_sent_at(user_id=user_id)
+    the_date = run_date or date.today()
     items, below = repo.get_scored_shortlist(
         threshold=threshold, since=since, max_age_days=max_age_days
     )
+
+    # B-1: build the full-list report + presign a link to it. NON-FATAL by contract — read,
+    # render, upload and presign are ALL inside the guard; any failure degrades the digest to
+    # plain text (full_list_url stays None) and is logged, never raised. The link is same-day
+    # reachability, never a reason the daily run fails.
+    full_list_url: str | None = None
+    if report_store is not None:
+        try:
+            all_scored = repo.get_all_scored(max_age_days=max_age_days)
+            report_html = render_full_list(
+                all_scored,
+                threshold=threshold,
+                run_date=the_date,
+                generated_at=datetime.now(timezone.utc),
+            )
+            report_key = f"reports/{the_date.isoformat()}/jobs-{run_id}.html"
+            report_store.put_report(html=report_html, key=report_key)
+            full_list_url = report_store.presign(key=report_key, expires=_REPORT_URL_EXPIRY_S)
+            log.info(
+                "notify: full-list report uploaded (run_id=%s key=%s jobs=%d)",
+                run_id, report_key, len(all_scored),
+            )
+        except Exception as exc:  # noqa: BLE001 — the link is an enhancement; NEVER fail the send
+            log.warning(
+                "notify: full-list report skipped (run_id=%s) — digest sends without a link: %s",
+                run_id, exc,
+            )
+            full_list_url = None
+
     subject, html_body, text_body = render_digest(
-        items, below, threshold=threshold, date=run_date or date.today(), since=since
+        items, below, threshold=threshold, date=the_date, since=since,
+        full_list_url=full_list_url,
     )
     # A send failure propagates (NotifierError) — the v0 surface is the email; a failed send is
     # a failed run, not a swallowed warning (mirrors the loud DB-failure stance in score_gold).

--- a/src/jobfetcher/core/notifier.py
+++ b/src/jobfetcher/core/notifier.py
@@ -200,6 +200,7 @@ def render_digest(
     threshold: int,
     date: "date",
     since: "datetime | None" = None,
+    full_list_url: str | None = None,
 ) -> tuple[str, str, str]:
     """Render `(subject, html_body, text_body)` for the daily digest.
 
@@ -207,6 +208,12 @@ def render_digest(
     Repository); `below_count` is how many scored matches fell below the threshold (the footer).
     `since` is when the LAST digest went out (`repo.get_last_digest_sent_at`) — `None` = the
     first-ever digest.
+
+    `full_list_url` (B-1) is a presigned https link to the full-list report page (every scored
+    job). When present it LINKIFIES the two otherwise-dead lines — the below-threshold footer
+    and the still-open "…and N more" overflow — so the compressed tail is reachable from the
+    email. It is scheme-allowlisted via `_safe_apply_url`; a hostile scheme (or `None`) degrades
+    gracefully to today's plain text (no link), never emitting an unsafe href.
 
     Digest truthfulness: the items are split into **"New since last digest"** (full cards,
     first; a graduation gets the green `↑ old→new` badge) and **"still open"** (a count + the
@@ -220,6 +227,9 @@ def render_digest(
     applied by the Repository) simply never reach this renderer. Emits BOTH an HTML body and
     a plaintext fallback."""
     day = date.isoformat()
+    # Scheme-allowlist the full-list link ONCE (untrusted-URL discipline, mirrors apply_url): a
+    # non-http(s) or None value → the two dead lines keep today's plain text (graceful).
+    safe_full_url = _safe_apply_url(full_list_url)
     new_items, _ = split_new_and_still_open(items, since=since, threshold=threshold)
     new_ids = {i.posting_id for i in new_items}
     new_cards: list[DigestCard] = []
@@ -274,9 +284,12 @@ def render_digest(
     for card in new_cards:
         text_lines.extend(_card_text_lines(card, threshold=threshold))
     if open_cards:
-        text_lines.extend(_still_open_text_lines(open_cards))
+        text_lines.extend(_still_open_text_lines(open_cards, safe_full_url))
     if footer:
-        text_lines.append(footer)
+        # B-1: linkify the below-threshold footer — the full list is where those N are reachable.
+        text_lines.append(
+            f"{footer} — see the full list: {safe_full_url}" if safe_full_url else footer
+        )
     text_body = "\n".join(text_lines) + "\n"
 
     # ---- HTML body (new section first: one card per group; then the compact still-open) ----
@@ -299,11 +312,18 @@ def render_digest(
                 "New since last digest</h3>"
             )
         new_html += "".join(_card_html(card, threshold=threshold) for card in new_cards)
-    open_html = _still_open_html(open_cards) if open_cards else ""
-    footer_html = (
-        f'<p style="color:#80868b;font-size:13px;margin:8px 0 0;">{escape(footer)}</p>'
-        if footer else ""
-    )
+    open_html = _still_open_html(open_cards, safe_full_url) if open_cards else ""
+    if not footer:
+        footer_html = ""
+    elif safe_full_url:
+        # B-1: the below-threshold footer becomes a link to the full-list page.
+        footer_html = (
+            f'<p style="color:#80868b;font-size:13px;margin:8px 0 0;">{escape(footer)} &mdash; '
+            f'<a href="{escape(safe_full_url, quote=True)}" '
+            f'style="color:{_APPLY_BG};text-decoration:none;">see the full list &rarr;</a></p>'
+        )
+    else:
+        footer_html = f'<p style="color:#80868b;font-size:13px;margin:8px 0 0;">{escape(footer)}</p>'
     html_body = _html_shell(day, summary + new_html + open_html + footer_html)
     return subject, html_body, text_body
 
@@ -332,9 +352,12 @@ def _card_text_lines(card: DigestCard, *, threshold: int) -> list[str]:
     return lines
 
 
-def _still_open_text_lines(cards: list[DigestCard]) -> list[str]:
+def _still_open_text_lines(
+    cards: list[DigestCard], full_list_url: str | None = None
+) -> list[str]:
     """The still-open section, plaintext: the count line + top-N compact one-liners + the
-    "…and n more — see your export" overflow line."""
+    "…and n more" overflow line. `full_list_url` (already scheme-checked) linkifies that
+    overflow line at the full-list page; without it, today's "see your export" text (B-1)."""
     on = len(cards)
     lines = [f"{on} earlier match{'es' if on != 1 else ''} still open:"]
     for card in cards[:_STILL_OPEN_TOP_N]:
@@ -345,7 +368,9 @@ def _still_open_text_lines(cards: list[DigestCard]) -> list[str]:
             f"{_safe_apply_url(rep.apply_url) or '(no link)'}"
         )
     if on > _STILL_OPEN_TOP_N:
-        lines.append(f"  …and {on - _STILL_OPEN_TOP_N} more — see your export")
+        more = on - _STILL_OPEN_TOP_N
+        tail = f"see the full list: {full_list_url}" if full_list_url else "see your export"
+        lines.append(f"  …and {more} more — {tail}")
     lines.append("")
     return lines
 
@@ -421,10 +446,11 @@ def _card_html(card: DigestCard, *, threshold: int) -> str:
     )
 
 
-def _still_open_html(cards: list[DigestCard]) -> str:
+def _still_open_html(cards: list[DigestCard], full_list_url: str | None = None) -> str:
     """The still-open section, HTML: the count heading + top-N compact one-liners
     (`{score} · {title} — {company} · Apply`) + the "…and n more" overflow line. Deliberately
-    NOT full cards — these already surfaced in an earlier digest; they stay reachable, not loud."""
+    NOT full cards — these already surfaced in an earlier digest; they stay reachable, not loud.
+    `full_list_url` (already scheme-checked) linkifies the overflow line to the full-list page."""
     on = len(cards)
     parts = [
         '<h3 style="color:#202124;font-size:15px;margin:20px 0 8px;">'
@@ -446,9 +472,17 @@ def _still_open_html(cards: list[DigestCard]) -> str:
             f"&mdash; {company}{link}</div>"
         )
     if on > _STILL_OPEN_TOP_N:
+        more = on - _STILL_OPEN_TOP_N
+        if full_list_url:
+            tail = (
+                f'<a href="{escape(full_list_url, quote=True)}" '
+                f'style="color:{_APPLY_BG};text-decoration:none;">see the full list &rarr;</a>'
+            )
+        else:
+            tail = "see your export"
         parts.append(
             '<p style="color:#80868b;font-size:13px;margin:6px 0 0;">'
-            f"&hellip;and {on - _STILL_OPEN_TOP_N} more &mdash; see your export</p>"
+            f"&hellip;and {more} more &mdash; {tail}</p>"
         )
     return "".join(parts)
 

--- a/src/jobfetcher/core/ports.py
+++ b/src/jobfetcher/core/ports.py
@@ -43,6 +43,11 @@ class ShortlistItem:
     fingerprint: str | None = None
     fetched_at: "datetime | None" = None
     scored_at: "datetime | None" = None
+    # B-1 (the full-list report — `get_all_scored` only): the human `score_override` and the
+    # latest application-outcome status. The daily-digest path (`get_scored_shortlist`) never
+    # sets these, so they stay None there and the digest renderer reads neither.
+    score_override: int | None = None
+    application_status: str | None = None
 
 
 class LlmError(Exception):
@@ -340,6 +345,19 @@ class Repository(Protocol):
 
         "Surfaced" matches Step 5's `surfaced`/`strong_fit` cut. Raises `RepositoryError` on a
         backend failure."""
+        ...
+
+    def get_all_scored(
+        self, *, max_age_days: "int | None" = None
+    ) -> "list[ShortlistItem]":
+        """Read EVERY scored posting — surfaced AND below-threshold — as `ShortlistItem`s ordered
+        by score DESC (the full-list report's input, B-1). The SAME `score`↔`posting`↔`bronze`
+        join as `get_scored_shortlist` but WITHOUT the threshold cut, plus `score_override` and
+        the latest `application_event.status` (a correlated newest-row subquery) on each item.
+
+        `max_age_days` bounds by posting age identically to `get_scored_shortlist` (unknown-age
+        rows INCLUDED; `None`/`0` = unbounded), so the report scopes to the same window the
+        digest does. Read-only. Raises `RepositoryError` on a backend failure."""
         ...
 
     def upsert_profile(

--- a/src/jobfetcher/core/report.py
+++ b/src/jobfetcher/core/report.py
@@ -1,0 +1,216 @@
+"""The full-list report (B-1): a single, self-contained HTML page listing EVERY scored job
+(surfaced + still-open + below-threshold) — score · override · fit · title · company · location ·
+application status · why/gaps · apply link · dates — so the daily digest's two dead-text lines
+("…and N more", "+N below") can point at the real data instead of at a LOCAL `scripts/export.py`
+the email can never reach.
+
+Dependency-free on purpose (P1): plain string templates, the same style as `core/notifier.py`.
+Unlike the email this is a **standalone web page**, so it MAY carry a `<style>` block and a small
+**inline vanilla `<script>`** for client-side sort/filter — no framework, no CDN, no external
+asset (self-contained by construction). All user/LLM text is HTML-escaped before interpolation
+(a JD title/company/reason is untrusted input); the apply link is scheme-allowlisted via the
+notifier's `_safe_apply_url` (no `javascript:`/`data:` href). `render_full_list([])` is a
+first-class case (VG5 spirit): a valid "no scored jobs yet" page, never a crash or a blank body.
+"""
+from __future__ import annotations
+
+from html import escape
+from typing import TYPE_CHECKING, Any
+
+from .notifier import (
+    _APPLY_BG,
+    _badge_color,
+    _display_title,
+    _location,
+    _safe_apply_url,
+)
+
+if TYPE_CHECKING:
+    from datetime import date, datetime
+
+    from .ports import ShortlistItem
+
+
+def _join(values: list[Any]) -> str:
+    """A JSONB list of short phrases (strengths/gaps) → a single `; `-joined line; blanks
+    dropped. Never leaks a `None`."""
+    return "; ".join(s for s in (str(v).strip() for v in (values or [])) if s)
+
+
+def _fmt_date(value: "datetime | date | None") -> str:
+    """A timestamp/date → its ISO `YYYY-MM-DD` (date only — the full list is a scan tool, not an
+    audit log); `None` → empty string."""
+    if value is None:
+        return ""
+    d = value.date() if hasattr(value, "date") else value
+    return d.isoformat()
+
+
+def _row_html(item: "ShortlistItem", *, threshold: int) -> str:
+    """One `<tr>` for the jobs table. `data-below` drives the below-threshold filter; the score
+    cell carries `data-sort` so the numeric sort is by value, not lexical text. Every user/LLM
+    field is escaped; the apply link is scheme-allowlisted."""
+    score = item.score
+    below = "1" if score < threshold else "0"
+    override = "" if item.score_override is None else str(item.score_override)
+    fit = escape((item.fit_category or "").replace("_", " ").strip())
+    title = escape(_display_title(item))
+    company = escape((item.company or "").strip())
+    loc = escape(_location(item))
+    status = escape((item.application_status or "").strip())
+    why = escape(_join(item.strengths))
+    gaps = escape(_join(item.gaps))
+    scored = escape(_fmt_date(item.scored_at))
+    fetched = escape(_fmt_date(item.fetched_at))
+    badge = _badge_color(item.fit_category)
+
+    safe_url = _safe_apply_url(item.apply_url)
+    apply_cell = (
+        f'<a href="{escape(safe_url, quote=True)}" target="_blank" rel="noopener noreferrer">Apply</a>'
+        if safe_url
+        else '<span class="muted">no link</span>'
+    )
+    return (
+        f'<tr data-below="{below}">'
+        f'<td class="num" data-sort="{score}">'
+        f'<span class="badge" style="background:{badge};">{score}</span></td>'
+        f'<td class="num" data-sort="{override or -1}">{override}</td>'
+        f"<td>{fit}</td>"
+        f'<td class="title">{title}</td>'
+        f"<td>{company}</td>"
+        f"<td>{loc}</td>"
+        f"<td>{status}</td>"
+        f'<td class="why">{why}</td>'
+        f'<td class="gaps">{gaps}</td>'
+        f"<td>{apply_cell}</td>"
+        f'<td class="date">{scored}</td>'
+        f'<td class="date">{fetched}</td>'
+        "</tr>"
+    )
+
+
+def render_full_list(
+    items: "list[ShortlistItem]",
+    *,
+    threshold: int,
+    run_date: "date",
+    generated_at: "datetime | None" = None,
+) -> str:
+    """Render the full-list HTML page over ALL scored `items` (surfaced + below-threshold, score
+    DESC). Returns a complete, self-contained `<!doctype html>` document (inline CSS + JS, no
+    external asset) suitable for upload to S3 and viewing from a presigned link.
+
+    `threshold` classifies each row (a below-threshold row is tagged for the "show below" filter);
+    `run_date`/`generated_at` label the header. `render_full_list([])` returns a valid
+    "no scored jobs yet" page — never a crash or a blank body (the digest's zero-scored path)."""
+    day = escape(run_date.isoformat())
+    gen = escape(generated_at.strftime("%Y-%m-%d %H:%M UTC")) if generated_at is not None else ""
+    total = len(items)
+    surfaced = sum(1 for i in items if i.score >= threshold)
+
+    if not items:
+        body = '<p class="empty">No scored jobs yet.</p>'
+    else:
+        rows = "".join(_row_html(i, threshold=threshold) for i in items)
+        body = f"""<div class="controls">
+  <input id="q" type="search" placeholder="Filter by title, company, location…" oninput="filterRows()" />
+  <label><input id="below" type="checkbox" checked onchange="filterRows()" /> show below-threshold</label>
+  <span class="count"><b id="shown">{total}</b> of {total} shown</span>
+</div>
+<div class="scroll">
+<table id="jobs">
+<thead><tr>
+  <th onclick="sortBy(0,true)">Score</th>
+  <th onclick="sortBy(1,true)">Override</th>
+  <th onclick="sortBy(2,false)">Fit</th>
+  <th onclick="sortBy(3,false)">Title</th>
+  <th onclick="sortBy(4,false)">Company</th>
+  <th onclick="sortBy(5,false)">Location</th>
+  <th onclick="sortBy(6,false)">Status</th>
+  <th>Why</th>
+  <th>Gaps</th>
+  <th>Apply</th>
+  <th onclick="sortBy(10,false)">Scored</th>
+  <th onclick="sortBy(11,false)">Fetched</th>
+</tr></thead>
+<tbody>{rows}</tbody>
+</table>
+</div>"""
+
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>JobFetcher — all scored jobs ({day})</title>
+<style>
+  body {{ margin:0; padding:24px 16px; background:#f4f5f7; color:#202124;
+    font-family:Arial,Helvetica,sans-serif; }}
+  .wrap {{ max-width:1200px; margin:0 auto; }}
+  h1 {{ font-size:20px; margin:0 0 4px; }}
+  .sub {{ color:#5f6368; font-size:13px; margin:0 0 16px; }}
+  .controls {{ display:flex; flex-wrap:wrap; gap:12px; align-items:center; margin:0 0 12px; }}
+  #q {{ padding:8px 10px; font-size:14px; border:1px solid #cdd0d4; border-radius:6px; min-width:240px; }}
+  .count {{ color:#5f6368; font-size:13px; }}
+  .scroll {{ overflow-x:auto; background:#fff; border:1px solid #e2e4e8; border-radius:8px; }}
+  table {{ border-collapse:collapse; width:100%; font-size:13px; }}
+  th, td {{ text-align:left; padding:8px 10px; border-bottom:1px solid #eceef1; vertical-align:top; }}
+  th {{ position:sticky; top:0; background:#f1f3f4; cursor:pointer; white-space:nowrap;
+    color:#3c4043; font-size:12px; }}
+  th:hover {{ background:#e4e7ea; }}
+  tbody tr:hover {{ background:#f8f9fa; }}
+  td.num {{ text-align:right; white-space:nowrap; }}
+  td.date {{ white-space:nowrap; color:#5f6368; }}
+  td.title {{ font-weight:bold; }}
+  td.why, td.gaps {{ max-width:280px; }}
+  td.gaps {{ color:#a8641b; }}
+  .badge {{ display:inline-block; color:#fff; font-weight:bold; padding:2px 8px; border-radius:12px; }}
+  .muted {{ color:#9aa0a6; font-style:italic; }}
+  a {{ color:{_APPLY_BG}; font-weight:bold; text-decoration:none; }}
+  a:hover {{ text-decoration:underline; }}
+  .empty {{ color:#5f6368; font-size:15px; }}
+</style>
+</head>
+<body>
+<div class="wrap">
+<h1>JobFetcher — all scored jobs</h1>
+<p class="sub">{day} &middot; {total} scored ({surfaced} at or above your threshold of {threshold})\
+{f" &middot; generated {gen}" if gen else ""}</p>
+{body}
+</div>
+<script>
+function filterRows() {{
+  var q = (document.getElementById('q').value || '').toLowerCase();
+  var showBelow = document.getElementById('below').checked;
+  var shown = 0;
+  var rows = document.querySelectorAll('#jobs tbody tr');
+  for (var i = 0; i < rows.length; i++) {{
+    var r = rows[i];
+    var matchText = r.textContent.toLowerCase().indexOf(q) !== -1;
+    var ok = matchText && (showBelow || r.getAttribute('data-below') !== '1');
+    r.style.display = ok ? '' : 'none';
+    if (ok) shown++;
+  }}
+  document.getElementById('shown').textContent = shown;
+}}
+function sortBy(col, numeric) {{
+  var tb = document.querySelector('#jobs tbody');
+  var rows = Array.prototype.slice.call(tb.rows);
+  var dir = (tb.getAttribute('data-col') === String(col) && tb.getAttribute('data-dir') === 'asc')
+    ? 'desc' : 'asc';
+  rows.sort(function (a, b) {{
+    var x = a.cells[col].getAttribute('data-sort');
+    var y = b.cells[col].getAttribute('data-sort');
+    if (x === null) x = a.cells[col].textContent.trim();
+    if (y === null) y = b.cells[col].textContent.trim();
+    if (numeric) {{ x = parseFloat(x) || 0; y = parseFloat(y) || 0; }}
+    else {{ x = x.toLowerCase(); y = y.toLowerCase(); }}
+    return (x < y ? -1 : x > y ? 1 : 0) * (dir === 'asc' ? 1 : -1);
+  }});
+  for (var i = 0; i < rows.length; i++) tb.appendChild(rows[i]);
+  tb.setAttribute('data-col', col);
+  tb.setAttribute('data-dir', dir);
+}}
+</script>
+</body>
+</html>"""

--- a/src/jobfetcher/handlers/pipeline.py
+++ b/src/jobfetcher/handlers/pipeline.py
@@ -39,6 +39,7 @@ from ..adapters.llm_openai import OpenAICompatLlmClient
 from ..adapters.repository_postgres import PostgresRepository
 from ..adapters.s3_config import read_config_text
 from ..adapters.s3_raw import S3RawStore
+from ..adapters.s3_reports import S3ReportStore
 from ..adapters.ses_notifier import SesNotifier
 from ..config import LlmConfig
 from ..core.dissector import Dissector
@@ -347,6 +348,7 @@ def handler(event: dict[str, Any] | None = None, context: Any = None) -> dict[st
         # Build the adapters (one place; each reads its own env var / secret path).
         source_adapter = JSearchSourceAdapter()
         raw_store = S3RawStore()
+        report_store = S3ReportStore()  # B-1: same data bucket; the full-list report + presign
         dissector = Dissector(
             OpenAICompatLlmClient(LlmConfig(model=_DISSECT_MODEL)), model_id=_DISSECT_MODEL
         )
@@ -442,6 +444,9 @@ def handler(event: dict[str, Any] | None = None, context: Any = None) -> dict[st
                 # Digest truthfulness: still-open matches older than this drop out of the
                 # digest (0 = keep forever) — the user knob, threaded like every other spec knob.
                 max_age_days=spec.digest_max_age_days,
+                # B-1: the full-list report + presigned link (best-effort inside notify —
+                # a report failure degrades the digest to plain text, never fails the run).
+                report_store=report_store,
             )
             # Mark sent ONLY after a successful send (notify raises on a failed send, so we never
             # get here on failure — the guard is not written, the next run re-sends).

--- a/tests/test_db_resume.py
+++ b/tests/test_db_resume.py
@@ -239,6 +239,7 @@ def _wire_handler(monkeypatch, tmp_path, calls: list[str], *, wait=None):
     monkeypatch.setattr(pipe, "wait_for_db_resume", _fake_wait)
     monkeypatch.setattr(pipe, "JSearchSourceAdapter", lambda: object())
     monkeypatch.setattr(pipe, "S3RawStore", lambda: object())
+    monkeypatch.setattr(pipe, "S3ReportStore", lambda: object())
     monkeypatch.setattr(pipe, "SesNotifier", lambda: object())
     monkeypatch.setattr(
         pipe, "OpenAICompatLlmClient", lambda cfg=None, **kw: object()  # noqa: ARG005

--- a/tests/test_integration_handler.py
+++ b/tests/test_integration_handler.py
@@ -216,10 +216,15 @@ def patched(monkeypatch, repo, db_url):
         ses.verify_email_identity(EmailAddress="from@jobfetcher.test")
 
         from jobfetcher.adapters.s3_raw import S3RawStore
+        from jobfetcher.adapters.s3_reports import S3ReportStore
         from jobfetcher.adapters.ses_notifier import SesNotifier
 
         monkeypatch.setattr(
             pipe, "S3RawStore", lambda: S3RawStore(bucket="jobfetcher-test-bucket", client=s3)
+        )
+        monkeypatch.setattr(
+            pipe, "S3ReportStore",
+            lambda: S3ReportStore(bucket="jobfetcher-test-bucket", client=s3),
         )
         monkeypatch.setattr(
             pipe, "SesNotifier", lambda: SesNotifier(sender="from@jobfetcher.test", client=ses)

--- a/tests/test_integration_notifier.py
+++ b/tests/test_integration_notifier.py
@@ -346,3 +346,75 @@ def test_get_last_digest_sent_at_none_then_max_and_user_scoped(repo):
     assert got is not None
     assert abs((got - t_newer).total_seconds()) < 1  # MAX of the user's rows...
     assert (now - got).total_seconds() > timedelta(days=19).total_seconds()  # ...not other's
+
+
+# --------------------------------------------------------------------------- full-list report (B-1)
+def test_get_all_scored_returns_surfaced_and_below_with_override_and_status(repo):
+    """B-1 over real SQL: `get_all_scored` returns the WHOLE scored set (surfaced AND below the
+    threshold), score DESC, and carries `score_override` (the human correction) + the latest
+    `application_event.status` via the correlated newest-row subquery."""
+    _truncate_pipeline(repo)
+    tag = uuid4().hex[:8]
+    hi, lo = f"hi-{tag}", f"lo-{tag}"
+    _seed_scored(repo, hi, "Senior Data Engineer", 92,
+                 company="Acme", apply_url="https://jobs.test/apply/hi")
+    _seed_scored(repo, lo, "Junior Analyst", 40,
+                 company="Gamma", apply_url="https://jobs.test/apply/lo")
+
+    rows = repo.get_all_scored()
+    ids = [r.posting_id for r in rows]
+    assert hi in ids and lo in ids  # the BELOW-threshold row is included, not dropped
+    assert [r.score for r in rows] == sorted((r.score for r in rows), reverse=True)  # score DESC
+
+    # a human override + an application outcome now round-trip onto the item
+    repo.track_application_event(posting_id=hi, status="applied")
+    repo.set_score_override(cluster_id=hi, score_override=99, fit_category="strong_fit",
+                            profile_hash="ph", previous_score=92)
+    (hi_row,) = [r for r in repo.get_all_scored() if r.posting_id == hi]
+    assert hi_row.score_override == 99
+    assert hi_row.application_status == "applied"
+
+
+def test_notify_writes_report_object_and_embeds_presigned_url(repo):
+    """End-to-end (real Postgres + moto S3 + moto SES): `notify` with a real `S3ReportStore`
+    writes a `reports/…` object (the full-list page listing surfaced + below) and embeds its
+    presigned URL in the sent digest — the artifact is reachable, not dead text."""
+    from jobfetcher.adapters.s3_reports import S3ReportStore
+    from jobfetcher.adapters.ses_notifier import SesNotifier
+
+    with mock_aws():
+        import boto3
+
+        s3 = boto3.client("s3", region_name="us-east-1")
+        s3.create_bucket(Bucket="jobfetcher-report-test")
+        ses = boto3.client("ses", region_name="us-east-1")
+        ses.verify_email_identity(EmailAddress="from@jobfetcher.test")
+
+        _truncate_pipeline(repo)
+        tag = uuid4().hex[:8]
+        user = f"user-{tag}"
+        _seed_profile(repo, user, threshold=60)
+        _seed_scored(repo, f"hi-{tag}", "Senior Data Engineer", 92,
+                     company="Acme", apply_url="https://jobs.test/apply/hi")
+        _seed_scored(repo, f"lo-{tag}", "Junior Analyst", 40,
+                     company="Gamma", apply_url="https://jobs.test/apply/lo")
+
+        notifier = SesNotifier(sender="from@jobfetcher.test", client=ses)
+        report_store = S3ReportStore(bucket="jobfetcher-report-test", client=s3)
+        out = notify(run_id="rr", repo=repo, notifier=notifier,
+                     recipient_email="report@jobfetcher.test", user_id=user,
+                     run_date=date(2026, 6, 27), report_store=report_store)
+        assert out["sent"] == 1
+
+        # the report object landed at the dated key and lists BOTH jobs (surfaced + below)
+        key = "reports/2026-06-27/jobs-rr.html"
+        keys = [o["Key"] for o in s3.list_objects_v2(Bucket="jobfetcher-report-test").get("Contents", [])]
+        assert key in keys
+        page = s3.get_object(Bucket="jobfetcher-report-test", Key=key)["Body"].read().decode("utf-8")
+        assert "Senior Data Engineer" in page and "Junior Analyst" in page
+        assert page.lower().startswith("<!doctype html>")
+
+        # the email embeds a presigned link to that exact key (the below-threshold footer)
+        mine = [m for m in _moto_sent_messages() if "report@jobfetcher.test" in m["destinations"]]
+        assert len(mine) == 1
+        assert key in mine[0]["body"]  # the presigned url path carries the report key

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -407,6 +407,49 @@ def test_dup_group_straddling_sections_renders_once_in_new():
     assert text.count("tw-old") == 1                       # ...and only once (no second line)
 
 
+# --------------------------------------------------------------------------- full-list link (B-1)
+_FULL_URL = "https://data.example.com/reports/2026-06-27/jobs-r.html?sig=abc"
+
+
+def test_full_list_url_linkifies_footer_and_overflow():
+    # B-1: with a full_list_url BOTH dead lines become clickable https links — the below-
+    # threshold footer AND the still-open "…and N more" overflow — in HTML and plaintext.
+    opens = [_item(90 - i, f"o{i}", scored_at=_STALE, company=f"Comp{i}ny") for i in range(6)]
+    _, html, text = render_digest(opens, below_count=3, threshold=60, date=date(2026, 6, 27),
+                                  since=_SINCE, full_list_url=_FULL_URL)
+    # HTML: the presigned link is an href on both lines; the old dead "see your export" is gone
+    assert f'href="{_FULL_URL}"' in html
+    assert html.count(f'href="{_FULL_URL}"') == 2  # overflow line + footer line
+    assert "see the full list" in html
+    assert "see your export" not in html
+    # plaintext: the url appears on both the overflow line and the footer line
+    assert f"see the full list: {_FULL_URL}" in text
+    assert text.count(_FULL_URL) == 2
+    assert "see your export" not in text
+    assert f"+3 more scored below your threshold of 60 — see the full list: {_FULL_URL}" in text
+
+
+def test_full_list_url_none_keeps_plain_text():
+    # graceful default: no full_list_url → today's plain text is unchanged (no link).
+    opens = [_item(90 - i, f"o{i}", scored_at=_STALE) for i in range(6)]
+    _, html, text = render_digest(opens, below_count=3, threshold=60, date=date(2026, 6, 27),
+                                  since=_SINCE)
+    assert "see the full list" not in html and "see the full list" not in text
+    assert "see your export" in html and "see your export" in text
+    assert "+3 more scored below your threshold of 60" in text
+
+
+def test_full_list_url_hostile_scheme_is_not_linkified():
+    # security: a hostile scheme on the full_list_url must NOT become a link — it degrades to
+    # today's plain text, exactly like a None url (reuses the _safe_apply_url allowlist).
+    opens = [_item(90 - i, f"o{i}", scored_at=_STALE) for i in range(6)]
+    _, html, text = render_digest(opens, below_count=3, threshold=60, date=date(2026, 6, 27),
+                                  since=_SINCE, full_list_url="javascript:alert(1)")
+    assert "javascript:" not in html.lower() and "javascript:" not in text.lower()
+    assert "see the full list" not in html  # no link emitted for the unsafe url
+    assert "see your export" in html and "see your export" in text  # degraded to plain text
+
+
 # --------------------------------------------------------------------------- SesNotifier
 class _FakeSes:
     """Captures send_email calls; returns a canned MessageId."""
@@ -500,6 +543,34 @@ class _FakeRepo:
         self.seen_since = since
         self.seen_max_age_days = max_age_days
         return list(self._surfaced), self._below
+
+    def get_all_scored(self, *, max_age_days=None):
+        # B-1: the full-list report input — the whole scored set (surfaced + below). The fake
+        # reuses the surfaced list (enough to render a page); records the age bound threaded in.
+        self.seen_all_max_age = max_age_days
+        return list(self._surfaced)
+
+
+class _FakeReportStore:
+    """Captures the full-list report upload + presign; can be forced to fail either step (the
+    B-1 non-fatal-degradation contract)."""
+
+    url = "https://data.example.com/reports/2026-06-27/jobs-r.html?sig=abc"
+
+    def __init__(self, *, fail_put: bool = False, fail_presign: bool = False) -> None:
+        self.puts: list[dict[str, Any]] = []
+        self._fail_put = fail_put
+        self._fail_presign = fail_presign
+
+    def put_report(self, *, html: str, key: str) -> None:
+        if self._fail_put:
+            raise RuntimeError("s3 put_object boom")
+        self.puts.append({"html": html, "key": key})
+
+    def presign(self, *, key: str, expires: int) -> str:
+        if self._fail_presign:
+            raise RuntimeError("presign boom")
+        return self.url
 
 
 class _FakeNotifier:
@@ -618,3 +689,77 @@ def test_notify_default_max_age_is_none_unbounded():
     repo = _FakeRepo(threshold=60, surfaced=[_item(90)], below=0)
     notify(run_id="r", repo=repo, notifier=_FakeNotifier(), recipient_email="to@x.com")
     assert repo.seen_max_age_days is None
+
+
+# --------------------------------------------------------------------------- notify() + report (B-1)
+def test_notify_with_report_store_builds_and_embeds_link():
+    # positive (mocked S3+repo): a report is uploaded at the dated key and its presigned https
+    # link is embedded in the digest (the below-threshold footer, since below=4).
+    repo = _FakeRepo(threshold=60, surfaced=[_item(90)], below=4)
+    store = _FakeReportStore()
+    notifier = _FakeNotifier()
+    out = notify(run_id="r", repo=repo, notifier=notifier, recipient_email="to@x.com",
+                 run_date=date(2026, 6, 27), report_store=store)
+    assert out == {"surfaced": 1, "below_threshold": 4, "sent": 1}
+    # uploaded once, at reports/{run_date}/jobs-{run_id}.html, with real HTML
+    assert len(store.puts) == 1
+    assert store.puts[0]["key"] == "reports/2026-06-27/jobs-r.html"
+    assert store.puts[0]["html"].lower().startswith("<!doctype html>")
+    # the presigned link is in BOTH bodies (linkified footer)
+    sent = notifier.sent[0]
+    assert store.url in sent["html"] and store.url in sent["text"]
+
+
+def test_notify_report_upload_failure_is_nonfatal():
+    # NEGATIVE #1a: the S3 upload raises → notify STILL sends (degraded, no link) and does not
+    # fail. (mark_digest_sent runs in the handler AFTER notify returns — so a non-raising notify
+    # is exactly what keeps the send-once guard writing.)
+    repo = _FakeRepo(threshold=60, surfaced=[_item(90)], below=4)
+    store = _FakeReportStore(fail_put=True)
+    notifier = _FakeNotifier()
+    out = notify(run_id="r", repo=repo, notifier=notifier, recipient_email="to@x.com",
+                 run_date=date(2026, 6, 27), report_store=store)
+    assert out["sent"] == 1  # the digest still went out
+    sent = notifier.sent[0]
+    assert store.url not in sent["html"] and store.url not in sent["text"]  # no link
+    assert "+4 more scored below your threshold of 60" in sent["text"]  # plain footer survives
+
+
+def test_notify_report_presign_failure_is_nonfatal():
+    # NEGATIVE #1b: the upload succeeds but presign raises → still sends, degraded to no link.
+    repo = _FakeRepo(threshold=60, surfaced=[_item(90)], below=4)
+    store = _FakeReportStore(fail_presign=True)
+    notifier = _FakeNotifier()
+    out = notify(run_id="r", repo=repo, notifier=notifier, recipient_email="to@x.com",
+                 run_date=date(2026, 6, 27), report_store=store)
+    assert out["sent"] == 1
+    assert store.url not in notifier.sent[0]["html"]
+
+
+def test_notify_zero_scored_with_report_store_still_sends():
+    # NEGATIVE #2: zero scored jobs + a report store → a valid "no matches" email still sends;
+    # the empty full-list page is built without crashing, and the run does not fail.
+    repo = _FakeRepo(threshold=60, surfaced=[], below=0)
+    store = _FakeReportStore()
+    notifier = _FakeNotifier()
+    out = notify(run_id="r", repo=repo, notifier=notifier, recipient_email="to@x.com",
+                 run_date=date(2026, 6, 27), report_store=store)
+    assert out == {"surfaced": 0, "below_threshold": 0, "sent": 1}
+    assert "no matches" in notifier.sent[0]["subject"].lower()
+
+
+def test_notify_no_report_store_sends_without_link():
+    # default: no report_store → get_all_scored is never called, digest has today's plain text.
+    repo = _FakeRepo(threshold=60, surfaced=[_item(90)], below=4)
+    notifier = _FakeNotifier()
+    notify(run_id="r", repo=repo, notifier=notifier, recipient_email="to@x.com")
+    assert not hasattr(repo, "seen_all_max_age")  # the report path was not taken
+    assert "see the full list" not in notifier.sent[0]["html"]
+
+
+def test_notify_threads_max_age_to_get_all_scored():
+    # the report scopes to the SAME age window as the digest (spec.digest_max_age_days).
+    repo = _FakeRepo(threshold=60, surfaced=[_item(90)], below=1)
+    notify(run_id="r", repo=repo, notifier=_FakeNotifier(), recipient_email="to@x.com",
+           report_store=_FakeReportStore(), max_age_days=90)
+    assert repo.seen_all_max_age == 90

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,0 +1,120 @@
+"""Unit tests for the full-list report renderer (B-1): `render_full_list` produces a valid,
+SELF-CONTAINED HTML page listing EVERY scored job (surfaced + below-threshold) — no external
+asset, all user/LLM text escaped, the apply link scheme-allowlisted, and `render_full_list([])`
+a valid "no jobs" page (never a crash/blank). Each carries a negative."""
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from typing import Any
+
+from jobfetcher.core.ports import ShortlistItem
+from jobfetcher.core.report import render_full_list
+
+_GEN = datetime(2026, 7, 10, 6, 0, tzinfo=timezone.utc)
+
+
+def _item(score: int, pid: str = "p", **over: Any) -> ShortlistItem:
+    base: dict[str, Any] = {
+        "posting_id": pid,
+        "title": "Senior Data Engineer",
+        "company": "Acme Corp",
+        "apply_url": "https://jobs.example.com/apply/123",
+        "normalized_title": "Data Engineer",
+        "score": score,
+        "fit_category": "strong_fit",
+        "strengths": ["strong Python", "fintech background"],
+        "gaps": ["no Spark"],
+        "strategic_assessment": "Lead with the pipeline project.",
+        "city": "Riyadh",
+        "country": "sa",
+        "scored_at": datetime(2026, 7, 9, 9, 0, tzinfo=timezone.utc),
+    }
+    base.update(over)
+    return ShortlistItem(**base)
+
+
+def test_render_full_list_is_self_contained_valid_page():
+    # a full standalone HTML doc: doctype + inline <style> + inline <script>, and NOTHING
+    # external (no CDN link/script/font/image) — the CSP-free page is self-contained.
+    items = [_item(90, "a"), _item(72, "b", company="Beta Ltd")]
+    html = render_full_list(items, threshold=60, run_date=date(2026, 7, 10), generated_at=_GEN)
+    low = html.lower()
+    assert low.startswith("<!doctype html>")
+    assert "<style>" in low and "<script>" in low
+    assert "<table" in low and "</html>" in low
+    # no external asset of any kind
+    assert "http-equiv" not in low  # no meta-refresh redirect
+    assert "<link" not in low and "cdn" not in low
+    assert "src=" not in low  # no external script/image src
+    # every job is listed
+    assert "Acme Corp" in html and "Beta Ltd" in html
+    assert "90" in html and "72" in html
+    assert "2026-07-10" in html  # the run-date header
+
+
+def test_render_full_list_includes_below_threshold_rows_tagged():
+    # the whole point (B-1): below-threshold jobs ARE listed (tagged for the filter), not hidden.
+    items = [
+        _item(90, "hi"),
+        _item(40, "lo", normalized_title="Junior Analyst", company="Gamma"),
+    ]
+    html = render_full_list(items, threshold=60, run_date=date(2026, 7, 10))
+    assert "Junior Analyst" in html and "Gamma" in html  # the below-threshold row is present
+    assert 'data-below="1"' in html  # tagged below (the "show below-threshold" filter reads it)
+    assert 'data-below="0"' in html  # the surfaced row tagged not-below
+    # the header counts honestly: 2 scored, 1 at/above threshold
+    assert "2 scored" in html and "1 at or above your threshold of 60" in html
+
+
+def test_render_full_list_shows_override_and_application_status():
+    item = _item(80, "x", score_override=95, application_status="applied")
+    html = render_full_list([item], threshold=60, run_date=date(2026, 7, 10))
+    assert "95" in html          # the human override
+    assert "applied" in html      # the latest application-outcome status
+
+
+def test_render_full_list_escapes_hostile_user_content():
+    # security: a hostile title/company must be escaped, never injected as raw HTML.
+    item = _item(80, title="<script>x</script>", company="A & B <b>", normalized_title=None)
+    html = render_full_list([item], threshold=60, run_date=date(2026, 7, 10))
+    assert "<script>x</script>" not in html  # the raw tag must not survive
+    assert "&lt;script&gt;x&lt;/script&gt;" in html
+    assert "A &amp; B" in html
+
+
+def test_render_full_list_rejects_javascript_apply_url():
+    # security: a hostile scheme on the untrusted apply_url must NOT become a clickable link.
+    item = _item(80, apply_url="javascript:alert(1)")
+    html = render_full_list([item], threshold=60, run_date=date(2026, 7, 10))
+    assert "javascript:" not in html.lower()
+    assert "no link" in html  # the row shows a plain "no link" state instead of an anchor
+
+
+def test_render_full_list_escapes_apply_url_attribute_breakout():
+    # an https url crafted to break out of the href: the scheme passes, but the quote is escaped.
+    item = _item(80, apply_url='https://x.com/" onmouseover="alert(1)')
+    html = render_full_list([item], threshold=60, run_date=date(2026, 7, 10))
+    assert 'onmouseover="alert(1)"' not in html
+    assert "&quot;" in html
+
+
+def test_render_full_list_empty_is_valid_page():
+    # VG5 spirit: zero scored jobs → a valid page (never a crash/blank), no table.
+    html = render_full_list([], threshold=60, run_date=date(2026, 7, 10), generated_at=_GEN)
+    assert html.strip()
+    assert html.lower().startswith("<!doctype html>")
+    assert "No scored jobs yet" in html
+    assert "0 scored" in html
+
+
+def test_render_full_list_none_fields_do_not_crash():
+    # an item with None company/apply_url/status/override + empty strengths renders cleanly.
+    item = _item(
+        0, "z", company=None, apply_url=None, strategic_assessment=None,
+        strengths=[], gaps=[], normalized_title=None, score_override=None,
+        application_status=None, scored_at=None, fetched_at=None,
+    )
+    html = render_full_list([item], threshold=60, run_date=date(2026, 7, 10))
+    assert "None" not in html  # no None leaked into the output
+    assert "Senior Data Engineer" in html  # raw-title fallback
+    assert "no link" in html

--- a/tests/test_s3_reports.py
+++ b/tests/test_s3_reports.py
@@ -1,0 +1,63 @@
+"""Isolated `S3ReportStore` unit tests (no AWS, no moto): the unset-bucket clear error, the
+`put_report` object shape, and `presign` delegating to `generate_presigned_url`. Each carries a
+negative. Mirrors `test_s3_raw.py`."""
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from jobfetcher.adapters.s3_reports import _BUCKET_ENV, S3ReportStore
+
+
+class _FakeS3:
+    """Captures `put_object` + `generate_presigned_url` calls."""
+
+    def __init__(self) -> None:
+        self.puts: list[dict[str, Any]] = []
+        self.presigns: list[dict[str, Any]] = []
+
+    def put_object(self, **kw: Any) -> dict:
+        self.puts.append(kw)
+        return {}
+
+    def generate_presigned_url(self, op: str, *, Params: dict, ExpiresIn: int) -> str:  # noqa: N803
+        self.presigns.append({"op": op, "Params": Params, "ExpiresIn": ExpiresIn})
+        return f"https://signed.example.com/{Params['Key']}?e={ExpiresIn}"
+
+
+def test_unset_bucket_raises_clear_error(monkeypatch):
+    # negative: no bucket env and no explicit bucket → a clear, actionable error.
+    monkeypatch.delenv(_BUCKET_ENV, raising=False)
+    with pytest.raises(ValueError, match=_BUCKET_ENV):
+        S3ReportStore()
+
+
+def test_blank_bucket_env_raises(monkeypatch):
+    monkeypatch.setenv(_BUCKET_ENV, "   ")
+    with pytest.raises(ValueError, match=_BUCKET_ENV):
+        S3ReportStore()
+
+
+def test_put_report_writes_html_object():
+    client = _FakeS3()
+    store = S3ReportStore(bucket="b", client=client)
+    store.put_report(html="<html>hi</html>", key="reports/2026-07-10/jobs-r.html")
+    assert len(client.puts) == 1
+    call = client.puts[0]
+    assert call["Bucket"] == "b"
+    assert call["Key"] == "reports/2026-07-10/jobs-r.html"
+    assert call["Body"] == b"<html>hi</html>"
+    assert call["ContentType"] == "text/html; charset=utf-8"
+
+
+def test_presign_delegates_to_generate_presigned_url():
+    client = _FakeS3()
+    store = S3ReportStore(bucket="b", client=client)
+    url = store.presign(key="reports/2026-07-10/jobs-r.html", expires=3600)
+    assert url == "https://signed.example.com/reports/2026-07-10/jobs-r.html?e=3600"
+    assert len(client.presigns) == 1
+    call = client.presigns[0]
+    assert call["op"] == "get_object"
+    assert call["Params"] == {"Bucket": "b", "Key": "reports/2026-07-10/jobs-r.html"}
+    assert call["ExpiresIn"] == 3600


### PR DESCRIPTION
## B-1 — Reachable full job list from the digest

The daily digest compressed **~281 of 286 scored jobs** into two lines of **dead, non-clickable text** ("…and N more — see your export" · "+N below your threshold"). This makes them reachable: a **single self-contained HTML page** of all scored jobs (sortable/filterable, mobile-friendly, no framework/CDN) is written to S3 `reports/{run_date}/jobs-{run_id}.html`, presigned, and linked in **both** lines.

**Non-crucial** — no migration, no Terraform/IAM change, no new dependency (S3 `PutObject` is already granted bucket-wide). Artifact build/upload/presign failure is **non-fatal**: the digest still sends, degrading to today's plain text. The email send itself stays loud/unchanged.

### Squad trail (ADR-0019)
- **Investigator** — ranked this the top squad-actionable bottleneck (verified live: 286 scored / 61 above / 225 below threshold). B-2 (Gmail-spam deliverability) escalated separately — it needs a sender domain, which the squad can't provision.
- **Surgeon** — minimal diff: new `core/report.py` (pure, dependency-free render) + `adapters/s3_reports.py` (lazy-boto3, mirrors `s3_raw.py`) + `Repository.get_all_scored` + notifier linkify + a non-fatal `notify` guard.
- **Examiner** (fresh-context, adversarial, two passes) — **CLEAN PASS, zero blocking**: verified the non-fatal guard's blast radius, the `get_all_scored` SQL correctness, and URL safety (ran hostile inputs — zero injection survived).

### Tests
**385 unit passed (+67 new), `ruff check` clean.** Integration tests written (they run in CI against the `postgres:16-alpine` service; skipped on the dev box to avoid truncating the real dev DB).

### ⚠️ Live-smoke item (post-deploy — a verification step, not a blocker)
`get_all_scored`'s correlated `application_event` subquery is the one construct not yet exercised over the Aurora **Data API** dialect (the ERR-004/005 class). It compiles to standard SQL and passes on local/CI Postgres; confirm on the live stack post-deploy. It's non-fatal-wrapped, so a Data-API quirk degrades to plain text rather than crashing the run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a full-list HTML report containing all scored jobs, including below-threshold results.
  - Reports include search, sorting, filtering, scores, application status, and safe application links.
  - Daily email digests can now include a secure, time-limited link to the full report.
  - Full reports are stored and shared through secure hosted links.

- **Bug Fixes**
  - Report generation or sharing failures no longer prevent the daily digest from being sent.
  - Unsafe links and user-provided content are safely handled in reports and emails.

- **Tests**
  - Added coverage for report rendering, security, storage, links, and notification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->