### PR TITLE
feat(scorer): boundary self-consistency + honest graduations

### DIFF
--- a/scripts/preview_digest.py
+++ b/scripts/preview_digest.py
@@ -69,12 +69,13 @@ _SAMPLE = [
         strengths=["Strong Python/SQL + dbt"], gaps=[], city="Dubai", country="ae",
         fingerprint="fp-qode-de-dxb", scored_at=_FRESH,
     ),
-    ShortlistItem(  # a graduation: 55 → 72 crossed the threshold (60) → green ↑ badge
-        posting_id="3", title="Analytics Engineer", company="Tamara",
+    ShortlistItem(  # a graduation: 55 → 72 crossed the threshold (60) under a CHANGED profile
+        posting_id="3", title="Analytics Engineer", company="Tamara",  # → green ↑ badge
         apply_url="https://jobs.example.com/apply/3", normalized_title="Analytics Engineer",
         score=72, fit_category="strong_fit",
         strengths=["dbt + warehouse modeling"], gaps=["Looker experience"],
         city="Riyadh", country="sa", previous_score=55, scored_at=_FRESH,
+        prior_profile_changed=True,  # a real skill gain drove the crossing (not LLM noise)
     ),
     ShortlistItem(
         posting_id="4", title="Data Architect", company="Alfanar",

--- a/src/jobfetcher/adapters/repository_postgres.py
+++ b/src/jobfetcher/adapters/repository_postgres.py
@@ -339,9 +339,24 @@ class PostgresRepository:
 
         **`max_age_days=None` or `0` = UNBOUNDED** (the pre-0004 behavior: every scored
         posting is reassessed, no age cut)."""
-        s, p = tables.score, tables.posting
+        s, p, se = tables.score, tables.posting, tables.score_event
+        # The profile_hash the CURRENT score was produced under = the latest lineage event for
+        # the cluster (save_score dual-writes score + score_event in one txn, so the newest event
+        # matches the current `score`). reassess() compares it to the profile it is about to
+        # score against, so a threshold crossing under an UNCHANGED profile is honestly NOT a
+        # graduation (it is LLM sampling noise). A scalar correlated subquery — the get_all_scored
+        # latest_status pattern; NULL for a pre-0004 row with no event yet.
+        prior_profile_hash = (
+            select(se.c.profile_hash)
+            .where(se.c.cluster_id == s.c.cluster_id)
+            .order_by(se.c.event_id.desc())
+            .limit(1)
+            .scalar_subquery()
+        )
         joined = p.join(s, p.c.cluster_id == s.c.cluster_id)
-        stmt = select(p, s.c.score, s.c.fit_category)
+        stmt = select(
+            p, s.c.score, s.c.fit_category, prior_profile_hash.label("prior_profile_hash")
+        )
         if max_age_days is not None and max_age_days > 0:
             b = tables.bronze_posting
             cutoff = datetime.now(timezone.utc) - timedelta(days=max_age_days)
@@ -363,6 +378,7 @@ class PostgresRepository:
                 _dissected_from_row(row),
                 row["score"],
                 row["fit_category"],
+                row["prior_profile_hash"],
             )
             for row in rows
         ]
@@ -595,8 +611,32 @@ class PostgresRepository:
         # `max_age_days` > 0 drops rows older than the bound-parameter cutoff — from the
         # surfaced list AND the below count (an aged-out job vanishes from the digest
         # entirely); an unknown-age row (COALESCE'd NULL) is INCLUDED, same rule as reassess.
-        s, p, b = tables.score, tables.posting, tables.bronze_posting
+        s, p, b, se = (
+            tables.score, tables.posting, tables.bronze_posting, tables.score_event
+        )
         age_source = func.coalesce(p.c.fetched_at, b.c.fetched_at)
+        # Honest graduations (belt-and-suspenders to the boundary resample): a graduation badge
+        # must reflect a real profile change, not LLM sampling noise. Compare the profile_hash of
+        # the two most-recent lineage events for the cluster — the one that produced the current
+        # `score` (latest) vs the one that produced `previous_score` (the immediately-prior event,
+        # since save_score dual-writes score + score_event together). Different ⇒ the crossing was
+        # profile-driven; same (or no prior event) ⇒ noise / first scoring ⇒ NO badge. Two scalar
+        # correlated subqueries; the boolean is formed in Python below.
+        latest_ph = (
+            select(se.c.profile_hash)
+            .where(se.c.cluster_id == s.c.cluster_id)
+            .order_by(se.c.event_id.desc())
+            .limit(1)
+            .scalar_subquery()
+        )
+        prior_ph = (
+            select(se.c.profile_hash)
+            .where(se.c.cluster_id == s.c.cluster_id)
+            .order_by(se.c.event_id.desc())
+            .limit(1)
+            .offset(1)
+            .scalar_subquery()
+        )
         joined = (
             select(
                 p.c.posting_id,
@@ -615,6 +655,8 @@ class PostgresRepository:
                 s.c.previous_score,
                 s.c.scored_at,
                 age_source.label("effective_fetched_at"),
+                latest_ph.label("latest_profile_hash"),
+                prior_ph.label("prior_profile_hash"),
             )
             .select_from(
                 s.join(p, s.c.cluster_id == p.c.cluster_id).outerjoin(
@@ -642,6 +684,12 @@ class PostgresRepository:
             if score is None:
                 continue  # an un-scored join artifact never surfaces or counts as below
             if score >= threshold:
+                # Honest-graduation signal: the two most-recent events differ ⇒ the profile that
+                # produced `previous_score` differs from the one that produced `score` (a real
+                # profile change drove the crossing, not noise). A missing prior event (first
+                # scoring) ⇒ False ⇒ no badge.
+                prior = row["prior_profile_hash"]
+                prior_profile_changed = prior is not None and prior != row["latest_profile_hash"]
                 surfaced.append(
                     ShortlistItem(
                         posting_id=row["posting_id"],
@@ -660,6 +708,7 @@ class PostgresRepository:
                         fingerprint=row["fingerprint"],
                         fetched_at=row["effective_fetched_at"],
                         scored_at=row["scored_at"],
+                        prior_profile_changed=prior_profile_changed,
                     )
                 )
             else:

--- a/src/jobfetcher/adapters/repository_postgres.py
+++ b/src/jobfetcher/adapters/repository_postgres.py
@@ -621,7 +621,10 @@ class PostgresRepository:
         # `score` (latest) vs the one that produced `previous_score` (the immediately-prior event,
         # since save_score dual-writes score + score_event together). Different ⇒ the crossing was
         # profile-driven; same (or no prior event) ⇒ noise / first scoring ⇒ NO badge. Two scalar
-        # correlated subqueries; the boolean is formed in Python below.
+        # correlated subqueries; the boolean is formed in Python below. (Edge, accepted: a
+        # `human-override` event landing between two scorings can shift the "2nd-latest" — but an
+        # override changes `score_override`, not `score`/`previous_score`, so the badge condition
+        # is unaffected in practice; not worth filtering the subqueries for a cosmetic case.)
         latest_ph = (
             select(se.c.profile_hash)
             .where(se.c.cluster_id == s.c.cluster_id)

--- a/src/jobfetcher/core/ingest.py
+++ b/src/jobfetcher/core/ingest.py
@@ -435,6 +435,7 @@ def _score_with_resample(
     threshold: int,
     trigger_margin: int,
     resample_n: int,
+    deadline: Deadline | None = None,
 ) -> "ScoreResult":
     """Score one posting once; resample near the boundary for self-consistency.
 
@@ -446,14 +447,20 @@ def _score_with_resample(
 
     Purity + isolation are preserved: the `Scorer` is untouched, and a `ScorerError`/`LlmError`
     from ANY sample propagates to the caller's per-item try/except (the posting is skipped, the
-    run continues) exactly as a single-score failure does today. The `deadline` is checked by the
-    caller BEFORE this runs (task-start granularity, unchanged); a boundary posting that has begun
-    runs its resample to completion inside the H-2 margin."""
+    run continues) exactly as a single-score failure does today.
+
+    **Deadline-aware (H-2 "never times out"):** the FIRST sample always runs — an in-flight task
+    completing its first score is the existing task-start contract — but each EXTRA sample is
+    gated: once `deadline` has passed we STOP and return the median of the samples collected so
+    far (`_median_sample` handles an even/short count), never STARTING a new score past the wall.
+    So resampling can never push a full-set reassess past the Lambda timeout."""
     first = scorer.score(dissected, profile)
     if resample_n <= 1 or abs(first.score - threshold) > trigger_margin:
         return first
     samples = [first]
     for _ in range(resample_n - 1):
+        if deadline is not None and deadline.expired:
+            break  # out of budget — median of what we have; never START a sample past the wall
         samples.append(scorer.score(dissected, profile))
     return _median_sample(samples)
 
@@ -521,6 +528,7 @@ def score_gold(
                 threshold=threshold,
                 trigger_margin=resample_margin,
                 resample_n=resample_n,
+                deadline=deadline,
             )
         except (ScorerError, LlmError) as exc:
             log.warning("scoring failed for %s (run_id=%s): %s", posting_id, run_id, exc)
@@ -650,6 +658,7 @@ def reassess(
                 threshold=threshold,
                 trigger_margin=resample_margin,
                 resample_n=resample_n,
+                deadline=deadline,
             )
         except (ScorerError, LlmError) as exc:
             log.warning("reassess scoring failed for %s (run_id=%s): %s", posting_id, run_id, exc)

--- a/src/jobfetcher/core/ingest.py
+++ b/src/jobfetcher/core/ingest.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
     from ..adapters.s3_raw import RawStore
     from ..adapters.s3_reports import ReportStore
     from .dissector import Dissector
+    from .models import DissectedPosting, ScoreResult
     from .ports import FilterStrategy, Notifier, Repository, SourceAdapter
     from .scorer import Scorer
     from .search_spec import SearchSpec
@@ -42,6 +43,25 @@ DEFAULT_USER_ID = "default"
 _DEFAULT_THRESHOLD = 60
 _DEFAULT_HARD_FLOOR = 50
 _DEFAULT_NEAR_MISS_BAND = 10
+
+# Boundary self-consistency (ADR-0028 lineage): the LLM score is non-deterministic — same input,
+# ~16pt average spread measured live (max 60) — so a single score near the shortlist cut is a
+# coin-flip on membership. When a posting's first score lands within RESAMPLE_TRIGGER_MARGIN of
+# the runtime threshold (the ambiguous zone, on BOTH sides of the cut), it is re-scored to
+# RESAMPLE_N total samples and the MEDIAN sample is kept — a coherent `ScoreResult` (its
+# narrative/subscores are the ones that produced its number), never an averaged frankenscore. A
+# clearly-in / clearly-out first score is kept after ONE call (the cost guard: resampling pays N×
+# ONLY on the ~1/5 of scores that sit at the boundary). `RESAMPLE_N <= 1` disables resampling
+# entirely (byte-for-byte the pre-boundary-resample behavior — one call, whatever it returns).
+#
+# The trigger margin defaults to 16 — the measured average spread, deliberately WIDER than the
+# default near_miss_band (10, which spans only BELOW the threshold), because sampling noise can
+# push a first score across the cut from EITHER side. It is an INDEPENDENT technical knob, never
+# coupled to the user's near_miss_band strictness (setting near_miss_band=0 must not disable the
+# noise guard). N defaults ODD (3) so the median is an exact single sample. Both are module knobs
+# with safe defaults + orchestrator params (never a required SearchSpec field — no config break).
+DEFAULT_RESAMPLE_N = 3
+DEFAULT_RESAMPLE_TRIGGER_MARGIN = 16
 
 log = logging.getLogger(__name__)
 
@@ -398,6 +418,46 @@ def _load_profile_and_knobs(
     return profile, threshold, hard_floor, near_miss_band
 
 
+def _median_sample(samples: "list[ScoreResult]") -> "ScoreResult":
+    """The sample carrying the median score — a COHERENT `ScoreResult` (its strengths/gaps/
+    assessment/subscores are the ones that produced its number), never an averaged frankenscore.
+    Samples are sorted by score and the lower-median index is returned, so an even N still yields
+    a real sample deterministically; an odd N (the default 3) is the exact median."""
+    ordered = sorted(samples, key=lambda r: r.score)
+    return ordered[(len(ordered) - 1) // 2]
+
+
+def _score_with_resample(
+    scorer: "Scorer",
+    dissected: "DissectedPosting",
+    profile: Profile,
+    *,
+    threshold: int,
+    trigger_margin: int,
+    resample_n: int,
+) -> "ScoreResult":
+    """Score one posting once; resample near the boundary for self-consistency.
+
+    The LLM score is non-deterministic, so a single score within `trigger_margin` of `threshold`
+    is a coin-flip on shortlist membership. In that ambiguous zone (checked on BOTH sides of the
+    cut) the posting is re-scored to `resample_n` TOTAL samples and the MEDIAN sample is returned
+    (`_median_sample` — a coherent judgment, never averaged). A clearly-in / clearly-out first
+    score, or `resample_n <= 1` (disabled), returns after EXACTLY ONE call — the cost guard.
+
+    Purity + isolation are preserved: the `Scorer` is untouched, and a `ScorerError`/`LlmError`
+    from ANY sample propagates to the caller's per-item try/except (the posting is skipped, the
+    run continues) exactly as a single-score failure does today. The `deadline` is checked by the
+    caller BEFORE this runs (task-start granularity, unchanged); a boundary posting that has begun
+    runs its resample to completion inside the H-2 margin."""
+    first = scorer.score(dissected, profile)
+    if resample_n <= 1 or abs(first.score - threshold) > trigger_margin:
+        return first
+    samples = [first]
+    for _ in range(resample_n - 1):
+        samples.append(scorer.score(dissected, profile))
+    return _median_sample(samples)
+
+
 def score_gold(
     *,
     run_id: str,
@@ -407,10 +467,18 @@ def score_gold(
     user_id: str = DEFAULT_USER_ID,
     max_workers: int = DEFAULT_MAX_WORKERS,
     deadline: Deadline | None = None,
+    resample_n: int = DEFAULT_RESAMPLE_N,
+    resample_margin: int = DEFAULT_RESAMPLE_TRIGGER_MARGIN,
 ) -> dict[str, int]:
     """Step-5 scoring: load the candidate profile + its **runtime** threshold knobs, then for
-    each gold candidate -> score it (LLM) -> derive its `fit_category` from the config bands
-    (VG8) -> upsert the `score` row (keyed on `cluster_id`) -> mark the posting `scored`.
+    each gold candidate -> score it (LLM, boundary-resampled) -> derive its `fit_category` from
+    the config bands (VG8) -> upsert the `score` row (keyed on `cluster_id`) -> mark it `scored`.
+
+    **Boundary self-consistency:** a candidate whose first score lands within `resample_margin`
+    of `threshold` is re-scored to `resample_n` samples and the MEDIAN sample is persisted, so a
+    non-deterministic score near the cut stops being a coin-flip on the shortlist (`_score_with_
+    resample`). `resample_n <= 1` disables it (identical to before). Cost falls only on the
+    boundary set; a clearly-in/out score is scored exactly once.
 
     `profile_hash` (required — the caller computes it from the profile+knobs it synced) is
     stamped, with `scorer.model_id` and `run_id`, on the `score_event` lineage row that
@@ -446,7 +514,14 @@ def score_gold(
         if deadline is not None and deadline.expired:
             return _DEFERRED  # out of time budget — leave for the next run
         try:
-            return scorer.score(dissected, profile)
+            return _score_with_resample(
+                scorer,
+                dissected,
+                profile,
+                threshold=threshold,
+                trigger_margin=resample_margin,
+                resample_n=resample_n,
+            )
         except (ScorerError, LlmError) as exc:
             log.warning("scoring failed for %s (run_id=%s): %s", posting_id, run_id, exc)
             return None
@@ -515,6 +590,8 @@ def reassess(
     user_id: str = DEFAULT_USER_ID,
     max_workers: int = DEFAULT_MAX_WORKERS,
     deadline: Deadline | None = None,
+    resample_n: int = DEFAULT_RESAMPLE_N,
+    resample_margin: int = DEFAULT_RESAMPLE_TRIGGER_MARGIN,
     max_age_days: int | None = None,
 ) -> dict[str, Any]:
     """Replay scoring over the already-scored postings against the **current** profile — no
@@ -532,10 +609,18 @@ def reassess(
     `COALESCE(posting.fetched_at, bronze.fetched_at)` and still INCLUDES a posting whose age
     is unknown even when the bound is set (see its docstring).
 
+    Same boundary self-consistency as `score_gold` (`_score_with_resample`): a re-score that
+    lands within `resample_margin` of `threshold` is resampled to `resample_n` and the MEDIAN
+    sample is kept, so a genuine profile change is what moves a score, not sampling noise.
+    `resample_n <= 1` disables it (identical to before).
+
     Returns `{reassessed, graduated, downgraded, unchanged, failed, deferred}` plus a
     `graduations` list (`posting_id/title/company/old_score→new_score/old_cat→new_cat`) — a
     **graduation** = a posting that newly reached at/above the threshold (`old < threshold <=
-    new`). The digest of these rides the email-UX unit; here they are reported + persisted.
+    new`) **AND whose prior score came from a DIFFERENT profile** (`prior_profile_hash !=
+    profile_hash`). A crossing under an unchanged profile is LLM noise, not a skill gain, so it
+    is counted `unchanged`, never announced. The digest of graduations rides the email-UX unit;
+    here they are reported + persisted.
 
     The report also carries the |new − old| **delta distribution** over the successfully
     reassessed postings (scoring-stability observability, an M7 input): `delta_buckets`
@@ -558,7 +643,14 @@ def reassess(
         if deadline is not None and deadline.expired:
             return _DEFERRED
         try:
-            return scorer.score(target[2], profile)  # target[2] = dissected
+            return _score_with_resample(  # target[2] = dissected
+                scorer,
+                target[2],
+                profile,
+                threshold=threshold,
+                trigger_margin=resample_margin,
+                resample_n=resample_n,
+            )
         except (ScorerError, LlmError) as exc:
             log.warning("reassess scoring failed for %s (run_id=%s): %s", posting_id, run_id, exc)
             return None
@@ -574,7 +666,9 @@ def reassess(
                 if result is None:
                     failed += 1
                     continue
-                posting_id, cluster_id, dissected, old_score, old_cat = futures[fut]
+                posting_id, cluster_id, dissected, old_score, old_cat, prior_profile_hash = (
+                    futures[fut]
+                )
                 new_cat = derive_fit_category(
                     result.score,
                     threshold=threshold,
@@ -600,7 +694,18 @@ def reassess(
                 )
                 reassessed += 1
                 deltas.append(abs(result.score - old_score))
-                if old_score < threshold <= result.score:  # crossed UP → graduated
+                # A graduation is a crossing UP *caused by a profile change* — the prior score
+                # came from a DIFFERENT profile than this run's. A crossing under the SAME
+                # profile is LLM sampling noise (the boundary resample already suppresses most),
+                # so it is folded into `unchanged`, never announced or badged.
+                crossed_up = old_score < threshold <= result.score
+                # An unknown prior hash (None — a pathological pre-0004 row with no lineage
+                # event) can't PROVE a profile change, so it is NOT a graduation — consistent
+                # with the digest side (`prior is not None and prior != latest`).
+                profile_changed = (
+                    prior_profile_hash is not None and prior_profile_hash != profile_hash
+                )
+                if crossed_up and profile_changed:  # honest graduation
                     graduated += 1
                     graduations.append(
                         {
@@ -614,7 +719,7 @@ def reassess(
                     )
                 elif old_score >= threshold > result.score:  # crossed DOWN → downgraded
                     downgraded += 1
-                else:  # both above or both below the threshold
+                else:  # both sides equal, or a same-profile (noise) crossing
                     unchanged += 1
     if deferred:
         log.warning(

--- a/src/jobfetcher/core/notifier.py
+++ b/src/jobfetcher/core/notifier.py
@@ -4,8 +4,9 @@ email — an HTML body **and** a plaintext fallback — for morning triage in 60
 
 The digest is TRUTHFUL about what changed: a **"New since last digest"** section leads with
 full cards — an item is new only when its judgment is FRESH (`scored_at > since`, the last
-digest send time) and that fresh judgment is news (a first scoring, or a graduation —
-`previous_score < threshold <= score` — badged green **↑ old→new**). Everything else above
+digest send time) and that fresh judgment is news (a first scoring, or an honest graduation —
+it crossed `threshold` AND under a *changed* profile, not LLM noise — badged green **↑ old→new**).
+Everything else above
 threshold lands in a compact **"still open"** section (count + the top 5 one-liners), so a
 repeat job never masquerades as news. Same-role repeats are **collapsed render-time by
 `fingerprint`** — one card per group, footnoted `seen n× — scores lo–hi`; a group straddling
@@ -76,9 +77,9 @@ def split_new_and_still_open(
 
     An item is NEW iff `since is None` (the first-ever digest — everything is new) OR its
     judgment is FRESH (`scored_at > since` — written after the last digest went out) AND that
-    fresh judgment is actually news: `previous_score is None` (a first scoring) or a
-    graduation (`previous_score < threshold <= score` — it just crossed the bar). Everything
-    else above threshold is STILL OPEN. Daily runs score a posting exactly ONCE, so a repeat's
+    fresh judgment is actually news: `previous_score is None` (a first scoring) or an HONEST
+    graduation (`_is_graduation` — it crossed the bar AND under a changed profile, not LLM
+    noise). Everything else above threshold is STILL OPEN. Daily runs score a posting exactly ONCE, so a repeat's
     `scored_at` predates the last digest and it lands still-open — `previous_score` alone
     cannot carry the split (it stays NULL forever in daily operation). A fresh NON-graduated
     re-score (reassess, `previous_score >= threshold`) is still-open too — being re-judged is
@@ -96,8 +97,7 @@ def split_new_and_still_open(
         if item.scored_at is None:
             new.append(item)  # unknown judgment time — defensively NEW, never hidden
         elif item.scored_at > since and (
-            item.previous_score is None
-            or item.previous_score < threshold <= item.score
+            item.previous_score is None or _is_graduation(item, threshold=threshold)
         ):
             new.append(item)
         else:
@@ -136,10 +136,18 @@ def collapse_duplicates(items: "list[ShortlistItem]") -> list[DigestCard]:
 
 
 def _is_graduation(item: "ShortlistItem", *, threshold: int) -> bool:
-    """True when this item just crossed the bar upward: `previous_score < threshold <= score`
-    (the ADR-0023 reassess graduation). `previous_score is None` = a first scoring — new, but
-    NOT a graduation (there is nothing to compare against), so it never gets a badge."""
-    return item.previous_score is not None and item.previous_score < threshold <= item.score
+    """True when this item just crossed the bar upward BECAUSE THE PROFILE CHANGED:
+    `previous_score < threshold <= score` AND the current score came from a different profile
+    than `previous_score` (`item.prior_profile_changed`). The profile gate is the honesty fix:
+    the LLM score is non-deterministic, so a crossing under the SAME profile (a re-score that
+    drifted up on noise) is NOT a graduation and never earns a badge — only a real skill/profile
+    gain does. `previous_score is None` = a first scoring — new, but not a graduation (nothing to
+    compare against)."""
+    return (
+        item.prior_profile_changed
+        and item.previous_score is not None
+        and item.previous_score < threshold <= item.score
+    )
 
 
 def _safe_apply_url(apply_url: str | None) -> str | None:

--- a/src/jobfetcher/core/ports.py
+++ b/src/jobfetcher/core/ports.py
@@ -43,6 +43,11 @@ class ShortlistItem:
     fingerprint: str | None = None
     fetched_at: "datetime | None" = None
     scored_at: "datetime | None" = None
+    # Honest graduations: True only when the profile that produced `previous_score` differs from
+    # the one that produced the current `score` (the two most-recent `score_event` profile_hashes)
+    # — so `_is_graduation` badges a crossing ONLY when a real profile change drove it, never LLM
+    # sampling noise. Defaults False (the report path + any caller that doesn't set it → no badge).
+    prior_profile_changed: bool = False
     # B-1 (the full-list report — `get_all_scored` only): the human `score_override` and the
     # latest application-outcome status. The daily-digest path (`get_scored_shortlist`) never
     # sets these, so they stay None there and the digest renderer reads neither.
@@ -230,12 +235,18 @@ class Repository(Protocol):
         self,
         *,
         max_age_days: int | None = None,
-    ) -> "list[tuple[str, str, DissectedPosting, int, str]]":
+    ) -> "list[tuple[str, str, DissectedPosting, int, str, str | None]]":
         """Read the reassess set (ADR-0023): every `status='scored'` posting + its CURRENT
         score and fit_category as `(posting_id, cluster_id, dissected, current_score,
-        current_fit_category)` — the replay's input, so `reassess()` can re-score against the
-        updated profile and report the old→new delta. **Ordered by `posting_id`** so a run is
-        deterministic.
+        current_fit_category, prior_profile_hash)` — the replay's input, so `reassess()` can
+        re-score against the updated profile and report the old→new delta. **Ordered by
+        `posting_id`** so a run is deterministic.
+
+        `prior_profile_hash` is the `profile_hash` the CURRENT score was produced under (the
+        latest `score_event` for the cluster) — `reassess()` compares it to the profile it is
+        about to score against, so a threshold crossing under an UNCHANGED profile is honestly
+        NOT a graduation (it is LLM sampling noise, not a skill gain). `None` when no lineage
+        event exists yet (a pre-0004 row).
 
         `max_age_days` bounds the replay by posting age (LLM-token thrift): when set and > 0,
         only postings fetched within the last N days are returned — a posting whose age is
@@ -329,13 +340,16 @@ class Repository(Protocol):
         surfaced/below split uses the one config knob — this method does not re-derive it.
 
         Digest truthfulness: each item also carries `previous_score`, `scored_at` (when the
-        current judgment was written), `fingerprint`, and the effective age `fetched_at`
+        current judgment was written), `fingerprint`, the effective age `fetched_at`
         (`COALESCE(posting.fetched_at, bronze.fetched_at)` — the reassess age source;
-        `posting.fetched_at` is NULL on live rows). The new/still-open split (`scored_at` vs
-        the last digest time, with `previous_score` for the graduation call) and the dup
-        grouping are computed RENDER-SIDE (pure functions in `core/notifier.py`), never here —
-        `since` (the last digest send time) is accepted on the port for that caller but does
-        not filter this query in v0.
+        `posting.fetched_at` is NULL on live rows), and `prior_profile_changed` (True iff the
+        two most-recent `score_event` profile_hashes for the cluster differ — the profile that
+        produced `previous_score` vs the one that produced `score`; a graduation badge fires
+        only when it does, so LLM sampling noise never earns one). The new/still-open split
+        (`scored_at` vs the last digest time, with `previous_score` + `prior_profile_changed`
+        for the graduation call) and the dup grouping are computed RENDER-SIDE (pure functions
+        in `core/notifier.py`), never here — `since` (the last digest send time) is accepted on
+        the port for that caller but does not filter this query in v0.
 
         `max_age_days` bounds the digest by posting age: when set and > 0, a row whose
         effective fetched-at is older than N days is DROPPED (from both the surfaced list and

--- a/tests/test_integration_handler.py
+++ b/tests/test_integration_handler.py
@@ -155,7 +155,9 @@ class _FakeLlm:
 
 
 # --------------------------------------------------------------------------- env / config
-def _write_config(tmp_path: Path, *, threshold: int = 60) -> tuple[str, str]:
+def _write_config(
+    tmp_path: Path, *, threshold: int = 60, extra_skill: str | None = None
+) -> tuple[str, str]:
     search = tmp_path / "search.yml"
     search.write_text(
         "source: jsearch\n"
@@ -180,12 +182,17 @@ def _write_config(tmp_path: Path, *, threshold: int = 60) -> tuple[str, str]:
         "  request_budget_per_run: 5\n",
         encoding="utf-8",
     )
+    # An added skill shifts compute_profile_hash → the reassess test uses it to model a real
+    # skill gain (a DIFFERENT profile_hash), so a threshold crossing is an HONEST graduation
+    # rather than same-profile LLM noise (ADR-0026 / the honest-graduation gate).
+    skills = "  - name: Python\n  - name: SQL\n"
+    if extra_skill:
+        skills += f"  - name: {extra_skill}\n"
     profile = tmp_path / "profile.yml"
     profile.write_text(
         "name: Tester\n"
         "skills:\n"
-        "  - name: Python\n"
-        "  - name: SQL\n"
+        f"{skills}"
         "preferences:\n"
         "  target_titles: ['Data Engineer']\n"
         "  target_locations: ['Riyadh']\n"
@@ -377,8 +384,11 @@ def test_handler_reassess_mode_replays_and_graduates(repo, patched, tmp_path, mo
     assert out1["statusCode"] == 200
     assert out1["score"]["scored"] == 2 and out1["score"]["surfaced"] == 0  # 60 < 80
 
-    # --- reassess: the re-score now returns 90 (profile "improved"); the source EXPLODES if
-    # fetched, proving replay never re-fetches ---
+    # --- reassess: the user gains a skill (the profile genuinely changes → a NEW profile_hash)
+    # and the re-score now returns 90. Both 60→90 crossings are HONEST graduations — a crossing
+    # is only badged when the profile actually changed, never on same-profile LLM noise (the
+    # negative is covered by test_reassess_same_profile_crossing_is_not_a_graduation). The
+    # source EXPLODES if fetched, proving replay never re-fetches. ---
     monkeypatch.setattr(pipe, "OpenAICompatLlmClient", lambda cfg=None, **kw: _LlmScoring(cfg.model, 90))
 
     class _ExplodingSource:
@@ -388,7 +398,8 @@ def test_handler_reassess_mode_replays_and_graduates(repo, patched, tmp_path, mo
 
     monkeypatch.setattr(pipe, "JSearchSourceAdapter", lambda: _ExplodingSource())
 
-    search_path, profile_path = _write_config(tmp_path, threshold=80)
+    # add a skill → a DIFFERENT profile_hash than run 1, so the crossing is a real skill gain
+    search_path, profile_path = _write_config(tmp_path, threshold=80, extra_skill="Spark")
     os.environ["SEARCH_CONFIG_PATH"] = search_path
     os.environ["PROFILE_PATH"] = profile_path
     os.environ["RECIPIENT_EMAIL"] = "to@jobfetcher.test"
@@ -397,7 +408,7 @@ def test_handler_reassess_mode_replays_and_graduates(repo, patched, tmp_path, mo
     assert out2["statusCode"] == 200 and out2["mode"] == "reassess"
     r = out2["reassess"]
     assert r["reassessed"] == 2
-    assert r["graduated"] == 2 and r["downgraded"] == 0  # both 60 → 90 crossed 80
+    assert r["graduated"] == 2 and r["downgraded"] == 0  # both 60 → 90 crossed 80, profile changed
     assert len(r["graduations"]) == 2
     assert {g["old_score"] for g in r["graduations"]} == {60}
     assert {g["new_score"] for g in r["graduations"]} == {90}
@@ -421,6 +432,12 @@ def test_handler_reassess_mode_replays_and_graduates(repo, patched, tmp_path, mo
     assert all(e.previous_score == 60 for e in events[2:])    # reassess carries the old
     assert all(e.run_id == "reassess1" for e in events[2:])
     assert all(e.profile_hash and e.scoring_model for e in events)
+    # honest-graduation driver: the profile genuinely changed between the two runs (a skill was
+    # added), so the reassess events carry a DIFFERENT profile_hash than the first scorings —
+    # precisely what makes the crossings graduations rather than same-profile noise.
+    assert events[0].profile_hash == events[1].profile_hash  # run 1 — profile P
+    assert events[2].profile_hash == events[3].profile_hash  # reassess — profile P' (P + Spark)
+    assert events[0].profile_hash != events[2].profile_hash  # P != P' → a real skill gain
     # the synced profile row carries the same hash the events were stamped with
     with repo.engine.connect() as conn:
         row_hash = conn.execute(_text("SELECT profile_hash FROM profile")).scalar_one()

--- a/tests/test_integration_notifier.py
+++ b/tests/test_integration_notifier.py
@@ -101,6 +101,18 @@ def _seed_scored(repo, posting_id: str, title: str, score: int, *, company: str,
     repo.mark_scored(posting_id)
 
 
+def _rescore(repo, posting_id: str, *, profile_hash: str, previous_score: int | None = None,
+             score: int = 72) -> None:
+    """Append a SECOND scoring event under `profile_hash` (the reassess shape) — so the cluster's
+    two most-recent `score_event` rows can carry different (or identical) profile_hashes, which is
+    what `get_scored_shortlist` compares for `prior_profile_changed`."""
+    repo.save_score(cluster_id=posting_id, score=score, fit_category="strong_fit",
+                    strengths=[f"re {posting_id}"], gaps=["no Spark"],
+                    strategic_assessment="play it well", poster_type="direct employer",
+                    legitimacy_verified=True, scoring_model="test-model",
+                    profile_hash=profile_hash, run_id="reassess", previous_score=previous_score)
+
+
 def _set_bronze_fetched_at(repo, posting_id: str, when: datetime) -> None:
     """Backdate the bronze landing time — the LIVE age source: `posting.fetched_at` stays NULL
     on every real row (`save_posting` never writes it), so `COALESCE` falls to bronze."""
@@ -313,6 +325,34 @@ def test_shortlist_carries_previous_score_fingerprint_and_age(repo):
     assert item.fingerprint == "fp-abc"
     assert item.fetched_at is not None  # the bronze landing time via the LEFT JOIN
     assert item.scored_at is not None   # save_score stamps it — the new/still-open signal
+
+
+def test_shortlist_prior_profile_changed_reflects_a_real_profile_change(repo):
+    """Honest graduations over real SQL: `get_scored_shortlist` sets `prior_profile_changed` True
+    iff the two most-recent `score_event` profile_hashes for the cluster differ — the profile that
+    produced `previous_score` vs the one that produced `score`. A re-score under a NEW profile →
+    True (a real change drove the crossing); a re-score under the SAME profile → False (LLM noise);
+    a first-only scoring → False (no prior event). This is the DB half of the graduation-badge fix
+    (the render-side gate `_is_graduation` reads the flag)."""
+    _truncate_pipeline(repo)
+    tag = uuid4().hex[:8]
+    changed, noise, first = f"chg-{tag}", f"noise-{tag}", f"first-{tag}"
+    # each seeded once (event #1 = ph-seed); all surface (score 72 >= 60); the two graduating
+    # ones carry previous_score=55 so the crossing condition also holds.
+    _seed_scored(repo, changed, "DE Changed", 72, company="A",
+                 apply_url="https://jobs.test/a", previous_score=55)
+    _seed_scored(repo, noise, "DE Noise", 72, company="B",
+                 apply_url="https://jobs.test/b", previous_score=55)
+    _seed_scored(repo, first, "DE First", 72, company="C", apply_url="https://jobs.test/c")
+    # event #2: `changed` re-scored under a DIFFERENT profile; `noise` under the SAME one.
+    _rescore(repo, changed, profile_hash="ph-NEW", previous_score=55)
+    _rescore(repo, noise, profile_hash="ph-seed", previous_score=55)
+
+    items, _ = repo.get_scored_shortlist(threshold=60)
+    by_id = {i.posting_id: i for i in items}
+    assert by_id[changed].prior_profile_changed is True   # ph-NEW != ph-seed → honest graduation
+    assert by_id[noise].prior_profile_changed is False    # ph-seed == ph-seed → LLM noise, no badge
+    assert by_id[first].prior_profile_changed is False    # only one event → no prior → no badge
 
 
 def test_get_last_digest_sent_at_none_then_max_and_user_scoped(repo):

--- a/tests/test_integration_score_event.py
+++ b/tests/test_integration_score_event.py
@@ -316,3 +316,16 @@ def test_age_filter_zero_and_none_are_unbounded(repo):
     ids_zero = {t[0] for t in repo.get_scored_for_reassess(max_age_days=0)}
     assert old in ids_none and old in ids_zero
     assert ids_none == ids_zero
+
+
+# --------------------------------------------------------------------------- honest graduations
+def test_get_scored_for_reassess_carries_prior_profile_hash(repo):
+    """The reassess honesty input over real SQL: the 6th tuple element is the profile_hash the
+    CURRENT score came from (the LATEST score_event for the cluster) — so reassess() can compare
+    it to the run's profile_hash and tell a real profile change from LLM sampling noise. After a
+    re-score under `ph-2`, the prior hash the reassess set reports is `ph-2` (not the seed hash)."""
+    pid = _seed_scored(repo, f"phash-{uuid4().hex[:8]}", score=55)  # event #1 → ph-seed
+    _save(repo, pid, 58, profile_hash="ph-2", run_id="r2", previous_score=55)  # event #2 → ph-2
+
+    by_id = {t[0]: t for t in repo.get_scored_for_reassess()}
+    assert by_id[pid][5] == "ph-2"  # the latest event's profile_hash = the current score's profile

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -205,7 +205,8 @@ def test_split_scored_at_vs_since_semantics():
     b = _item(75, "b", previous_score=None, scored_at=_FRESH)  # (b) fresh first scoring → NEW
     c = _item(88, "c", previous_score=88, scored_at=_FRESH)    # (c) fresh reassess, NOT a
     #     graduation → STILL OPEN even though the judgment is fresh (being re-judged isn't news)
-    d = _item(72, "d", previous_score=55, scored_at=_FRESH)    # (d) fresh graduation → NEW
+    d = _item(72, "d", previous_score=55, scored_at=_FRESH,     # (d) fresh HONEST graduation
+              prior_profile_changed=True)                       #     (profile changed) → NEW
     e = _item(70, "e", previous_score=50, scored_at=_STALE)    # (e) graduation that happened
     #     BEFORE the last digest → STILL OPEN (already announced, never re-announced)
     items = [a, b, c, d, e]
@@ -275,13 +276,26 @@ def test_collapse_missing_fingerprint_never_merges():
 
 # --------------------------------------------------------------------------- graduation badge
 def test_graduation_badge_renders_in_html_and_text():
-    # B1: a FRESH graduation (scored after the last digest, previous < threshold <= score) →
-    # the green ↑ old→new badge in BOTH bodies.
-    item = _item(72, previous_score=55, scored_at=_FRESH)
+    # B1: a FRESH, HONEST graduation (scored after the last digest, previous < threshold <= score,
+    # AND under a changed profile) → the green ↑ old→new badge in BOTH bodies.
+    item = _item(72, previous_score=55, scored_at=_FRESH, prior_profile_changed=True)
     _, html, text = render_digest([item], below_count=0, threshold=60,
                                   date=date(2026, 6, 27), since=_SINCE)
     assert "55&rarr;72" in html and "#137333" in html  # green text badge, old→new
     assert "↑ 55→72" in text
+
+
+def test_no_badge_when_profile_unchanged_even_though_score_crossed():
+    # THE honest-graduation negative (the exact scan bug): previous < threshold <= score AND a
+    # fresh judgment, BUT prior_profile_changed is False — the crossing is LLM sampling noise, not
+    # a skill gain. NO badge anywhere, and it lands STILL-OPEN (not announced as new).
+    item = _item(72, previous_score=55, scored_at=_FRESH, prior_profile_changed=False)
+    subject, html, text = render_digest([item], below_count=0, threshold=60,
+                                        date=date(2026, 6, 27), since=_SINCE)
+    assert "&#8593;" not in html and "55&rarr;72" not in html  # no green badge
+    assert "↑" not in text
+    assert "no new matches since" in subject.lower()  # folded to still-open, never announced
+    assert "1 earlier match still open" in html
 
 
 def test_no_badge_when_previous_already_above_threshold():

--- a/tests/test_reassess.py
+++ b/tests/test_reassess.py
@@ -50,12 +50,15 @@ def _profile_row(threshold=60):
             "hard_floor": 50, "near_miss_band": 10}
 
 
-def _targets():
-    # (posting_id, cluster_id, dissected, current_score, current_fit_category)
+def _targets(prior_hash="ph-old"):
+    # (posting_id, cluster_id, dissected, current_score, current_fit_category, prior_profile_hash)
+    # `prior_hash` is the profile the CURRENT score came from; default "ph-old" DIFFERS from the
+    # "ph-unit"/"ph-*" the tests score against, so a crossing is an HONEST graduation. Pass the
+    # SAME hash as the run's profile_hash to model a same-profile (noise) crossing (no graduation).
     return [
-        ("p-grad", "c-grad", _dissected("A"), 45, "misaligned"),   # was below 60
-        ("p-drop", "c-drop", _dissected("B"), 80, "strong_fit"),   # was above 60
-        ("p-same", "c-same", _dissected("C"), 90, "strong_fit"),   # stays above
+        ("p-grad", "c-grad", _dissected("A"), 45, "misaligned", prior_hash),  # was below 60
+        ("p-drop", "c-drop", _dissected("B"), 80, "strong_fit", prior_hash),  # was above 60
+        ("p-same", "c-same", _dissected("C"), 90, "strong_fit", prior_hash),  # stays above
     ]
 
 
@@ -69,8 +72,10 @@ def test_reassess_graduates_downgrades_and_tracks_previous_score():
     previous_score. max_workers=1 so the scripted FakeLlm maps to targets in order."""
     repo = _FakeReassessRepo(_profile_row(60), _targets())
     # new scores in target order: p-grad 45->75 (graduate), p-drop 80->40 (downgrade), p-same 90->92
+    # resample_n=1: this test scripts one reply PER target, so boundary resampling is disabled to
+    # keep the FakeLlm call→target mapping 1:1 (resampling is covered by its own tests below).
     report = reassess(run_id="r", repo=repo, profile_hash="ph-unit",
-                      scorer=_scorer_for([75, 40, 92]), max_workers=1)
+                      scorer=_scorer_for([75, 40, 92]), max_workers=1, resample_n=1)
 
     assert report["reassessed"] == 3
     assert report["graduated"] == 1
@@ -183,7 +188,7 @@ def test_score_then_reassess_appends_two_events():
     repo = _FakeFullRepo(
         _profile_row(60),
         candidates=[("p-1", "c-1", _dissected("A"))],
-        targets=[("p-1", "c-1", _dissected("A"), 55, "near_miss")],
+        targets=[("p-1", "c-1", _dissected("A"), 55, "near_miss", "ph-before")],
     )
     score_gold(run_id="r1", repo=repo, profile_hash="ph-before",
                scorer=_scorer_for([55]), max_workers=1)
@@ -206,15 +211,16 @@ def test_reassess_delta_distribution_bucket_edges_and_mean():
     0-5 / 6-10 / 6-10 / 11-20 / 11-20 / 21+ respectively (inclusive upper bounds); max=21;
     mean=(5+6+10+11+20+21)/6=12.1666… → 12.2 (1 decimal)."""
     targets = [
-        (f"p-{i}", f"c-{i}", _dissected(chr(65 + i)), old, "near_miss")
+        (f"p-{i}", f"c-{i}", _dissected(chr(65 + i)), old, "near_miss", "ph-old")
         for i, old in enumerate([50, 50, 50, 50, 50, 50])
     ]
     # new scores craft |new − old| = 5, 6, 10, 11, 20, 21 (mixing up- and down-moves to
-    # prove the distribution is over ABSOLUTE deltas)
+    # prove the distribution is over ABSOLUTE deltas). resample_n=1: one scripted reply per
+    # target, so boundary resampling is disabled to keep the call→target mapping exact.
     new_scores = [55, 44, 60, 39, 70, 29]
     repo = _FakeReassessRepo(_profile_row(60), targets)
     report = reassess(run_id="r", repo=repo, profile_hash="ph-unit",
-                      scorer=_scorer_for(new_scores), max_workers=1)
+                      scorer=_scorer_for(new_scores), max_workers=1, resample_n=1)
     assert report["reassessed"] == 6
     assert report["delta_buckets"] == {"0-5": 1, "6-10": 2, "11-20": 2, "21+": 1}
     assert report["max_delta"] == 21
@@ -238,10 +244,11 @@ def test_reassess_delta_distribution_excludes_failures():
                 raise ScorerError("boom")
             return ScoreResult.model_validate(json.loads(_score_json(48)))
 
-    # olds 45/80/90; successes score 48 → deltas |48-45|=3 and |48-90|=42 (the failed 80 absent)
+    # olds 45/80/90; successes score 48 → deltas |48-45|=3 and |48-90|=42 (the failed 80 absent).
+    # resample_n=1 so _MiddleBoom's 2nd call maps to the 2nd TARGET (not a resample of the 1st).
     repo = _FakeReassessRepo(_profile_row(60), _targets())
     report = reassess(run_id="r", repo=repo, profile_hash="ph-unit",
-                      scorer=_MiddleBoom(), max_workers=1)
+                      scorer=_MiddleBoom(), max_workers=1, resample_n=1)
     assert report["failed"] == 1 and report["reassessed"] == 2
     assert report["delta_buckets"] == {"0-5": 1, "6-10": 0, "11-20": 0, "21+": 1}
     assert report["max_delta"] == 42
@@ -256,7 +263,10 @@ def test_reassess_threads_subscores_into_save_score():
     subs = {name: 70 for name in FACTOR_WEIGHTS}
     repo = _FakeReassessRepo(_profile_row(60), _targets()[:2])
     scorer = Scorer(FakeLlm(_score_json(75, **subs), _score_json(80)))
-    reassess(run_id="r", repo=repo, profile_hash="ph-unit", scorer=scorer, max_workers=1)
+    # resample_n=1: one scripted reply per target — disable resampling so each target's blob is
+    # its own reply (resampling would mix the two replies and pick a median of a different one).
+    reassess(run_id="r", repo=repo, profile_hash="ph-unit", scorer=scorer, max_workers=1,
+             resample_n=1)
     with_subs = repo.saved["c-grad"]["subscores"]
     assert with_subs == {**subs, "code_total": 70, "llm_total": 75}
     assert repo.saved["c-drop"]["subscores"] is None  # omitted → NULL, never partial
@@ -282,3 +292,42 @@ def test_reassess_passes_max_age_days_through():
     reassess(run_id="r", repo=repo3, profile_hash="ph-unit",
              scorer=_scorer_for([70]), max_workers=1, max_age_days=0)
     assert repo3.max_age_days_seen == 0
+
+
+# --------------------------------------------------------------------------- honest graduations
+def test_reassess_graduation_requires_a_profile_change():
+    """Positive: the prior score came from a DIFFERENT profile ('ph-old' != 'ph-new') and the
+    re-score crosses the bar (45 -> 75) → a REAL graduation is counted + listed."""
+    repo = _FakeReassessRepo(_profile_row(60), _targets(prior_hash="ph-old")[:1])  # p-grad, old 45
+    report = reassess(run_id="r", repo=repo, profile_hash="ph-new",
+                      scorer=_scorer_for([75]), max_workers=1, resample_n=1)
+    assert report["graduated"] == 1
+    assert report["unchanged"] == 0
+    assert [g["posting_id"] for g in report["graduations"]] == ["p-grad"]
+
+
+def test_reassess_same_profile_crossing_is_not_a_graduation():
+    """The exact scan-bug negative: previous_score < threshold <= new_score BUT the prior score
+    came from the SAME profile ('ph-same' == 'ph-same') → the crossing is LLM sampling noise, not
+    a skill gain: NO graduation counted, an EMPTY graduations list, folded into `unchanged`. The
+    posting is still reassessed + saved (only the graduation JUDGMENT changes)."""
+    repo = _FakeReassessRepo(_profile_row(60), _targets(prior_hash="ph-same")[:1])  # p-grad, old 45
+    report = reassess(run_id="r", repo=repo, profile_hash="ph-same",
+                      scorer=_scorer_for([75]), max_workers=1, resample_n=1)
+    assert report["graduated"] == 0
+    assert report["graduations"] == []
+    assert report["unchanged"] == 1  # the crossing folds into unchanged, never announced
+    assert report["reassessed"] == 1
+    assert repo.saved["c-grad"]["score"] == 75  # the score itself still updates
+
+
+# --------------------------------------------------------------------------- boundary resample
+def test_reassess_resamples_boundary_and_keeps_median():
+    """Boundary self-consistency in the replay path: a first re-score near the threshold (62,
+    within the 16-pt margin of 60) is resampled to N=3 total and the MEDIAN sample is persisted
+    (median of 62/58/70 = 62) — the LLM is called exactly 3× for the one boundary posting."""
+    repo = _FakeReassessRepo(_profile_row(60), _targets()[:1])  # p-grad, old 45
+    llm = FakeLlm(_score_json(62), _score_json(58), _score_json(70))
+    reassess(run_id="r", repo=repo, profile_hash="ph-unit", scorer=Scorer(llm), max_workers=1)
+    assert repo.saved["c-grad"]["score"] == 62  # the median of the three boundary samples
+    assert len(llm.calls) == 3  # resampled to N total for the boundary posting

--- a/tests/test_scorer.py
+++ b/tests/test_scorer.py
@@ -560,3 +560,90 @@ def test_score_gold_lineage_differs_when_inputs_differ():
         "model-v1", "ph-before", "r1")
     assert (second["scoring_model"], second["profile_hash"], second["run_id"]) == (
         "model-v2", "ph-after", "r2")
+
+
+# --------------------------------------------------------------------------- boundary resample
+def test_median_sample_odd_is_exact_and_even_is_lower_median():
+    """`_median_sample` returns a REAL sample (never averaged): odd N → the exact middle by
+    score; even N → the lower-median, so the choice is deterministic and coherent."""
+    from jobfetcher.core.ingest import _median_sample
+
+    def _r(s):
+        return ScoreResult.model_validate(json.loads(_score_json(s)))
+
+    assert _median_sample([_r(70), _r(58), _r(62)]).score == 62          # odd → exact median
+    assert _median_sample([_r(50), _r(80), _r(60), _r(70)]).score == 60  # even → lower-median
+
+
+def test_score_with_resample_keeps_the_median_sample_narrative():
+    """The helper resamples a boundary score and returns the sample whose SCORE is the median —
+    a COHERENT ScoreResult (its strengths are the median sample's, not a frankenscore) — after
+    exactly N calls. Scores 62/58/70 near threshold 60 → median 62 with the 62-reply's narrative."""
+    from jobfetcher.core.ingest import _score_with_resample
+
+    llm = FakeLlm(
+        _score_json(62, strengths=["mid-sample"]),
+        _score_json(58, strengths=["low-sample"]),
+        _score_json(70, strengths=["high-sample"]),
+    )
+    out = _score_with_resample(Scorer(llm), _dissected(), _profile(),
+                               threshold=60, trigger_margin=16, resample_n=3)
+    assert out.score == 62
+    assert out.strengths == ["mid-sample"]  # the MEDIAN sample's own narrative, never averaged
+    assert len(llm.calls) == 3
+
+
+def test_score_with_resample_far_score_scores_once():
+    """The cost guard: a clearly-in first score (90, |90-60|=30 > margin 16) is NOT resampled —
+    exactly ONE LLM call, the first result returned untouched."""
+    from jobfetcher.core.ingest import _score_with_resample
+
+    llm = FakeLlm(_score_json(90), _score_json(58), _score_json(58))
+    out = _score_with_resample(Scorer(llm), _dissected(), _profile(),
+                               threshold=60, trigger_margin=16, resample_n=3)
+    assert out.score == 90
+    assert len(llm.calls) == 1  # never entered the resample loop
+
+
+def test_score_with_resample_disabled_scores_once():
+    """resample_n <= 1 disables resampling entirely — one call even for a boundary score
+    (identical to the pre-boundary-resample behavior)."""
+    from jobfetcher.core.ingest import _score_with_resample
+
+    llm = FakeLlm(_score_json(62), _score_json(58), _score_json(70))
+    out = _score_with_resample(Scorer(llm), _dissected(), _profile(),
+                               threshold=60, trigger_margin=16, resample_n=1)
+    assert out.score == 62
+    assert len(llm.calls) == 1
+
+
+def test_score_gold_resamples_boundary_and_persists_median():
+    """Through the orchestrator: a boundary candidate (first score 62 within margin of 60) is
+    resampled to N=3 and the MEDIAN (62 of 62/58/70) is what `save_score` persists; the LLM is
+    called 3× for the one candidate."""
+    repo = _FakeScoreRepo(_profile_row(60), _candidates()[:1], None)
+    llm = FakeLlm(_score_json(62), _score_json(58), _score_json(70))
+    score_gold(run_id="r", repo=repo, profile_hash="ph", scorer=Scorer(llm), max_workers=1)
+    assert repo.saved["c-low"]["score"] == 62  # the median, not the first sample
+    assert len(llm.calls) == 3
+
+
+def test_score_gold_clear_score_scores_once_cost_guard():
+    """The cost-guard negative through the orchestrator: a clearly-in score (90) is scored
+    EXACTLY once — resampling never fires away from the boundary."""
+    repo = _FakeScoreRepo(_profile_row(60), _candidates()[:1], None)
+    llm = FakeLlm(_score_json(90))
+    score_gold(run_id="r", repo=repo, profile_hash="ph", scorer=Scorer(llm), max_workers=1)
+    assert repo.saved["c-low"]["score"] == 90
+    assert len(llm.calls) == 1
+
+
+def test_score_gold_resample_disabled_matches_today():
+    """resample_n=1 → identical to before: a boundary score is persisted after ONE call (no
+    regression / opt-out path)."""
+    repo = _FakeScoreRepo(_profile_row(60), _candidates()[:1], None)
+    llm = FakeLlm(_score_json(62))
+    score_gold(run_id="r", repo=repo, profile_hash="ph", scorer=Scorer(llm), max_workers=1,
+               resample_n=1)
+    assert repo.saved["c-low"]["score"] == 62
+    assert len(llm.calls) == 1

--- a/tests/test_scorer.py
+++ b/tests/test_scorer.py
@@ -617,6 +617,29 @@ def test_score_with_resample_disabled_scores_once():
     assert len(llm.calls) == 1
 
 
+def test_score_with_resample_stops_resampling_at_the_deadline():
+    """H-2 'never times out': the FIRST sample always runs, but once the deadline has passed no
+    EXTRA sample is STARTED — the helper returns the median of what it has (here just the first).
+    A boundary score with an expired deadline → one call; the same with time left → the full
+    N-sample median (the extra samples are gated ONLY by the wall)."""
+    from jobfetcher.core.ingest import Deadline, _score_with_resample
+
+    # expired deadline: the first sample runs, the 2nd/3rd are never started
+    llm = FakeLlm(_score_json(62), _score_json(58), _score_json(70))
+    out = _score_with_resample(Scorer(llm), _dissected(), _profile(),
+                               threshold=60, trigger_margin=16, resample_n=3,
+                               deadline=Deadline(0))
+    assert out.score == 62  # the first (and only) sample — never averaged
+    assert len(llm.calls) == 1  # no further scorer.score calls past the wall
+
+    # a deadline with time left → normal N-sample median, unchanged
+    llm2 = FakeLlm(_score_json(62), _score_json(58), _score_json(70))
+    out2 = _score_with_resample(Scorer(llm2), _dissected(), _profile(),
+                                threshold=60, trigger_margin=16, resample_n=3,
+                                deadline=Deadline(60))
+    assert out2.score == 62 and len(llm2.calls) == 3  # 62/58/70 → median 62, all three sampled
+
+
 def test_score_gold_resamples_boundary_and_persists_median():
     """Through the orchestrator: a boundary candidate (first score 62 within margin of 60) is
     resampled to N=3 and the MEDIAN (62 of 62/58/70) is what `save_score` persists; the LLM is


### PR DESCRIPTION
## Boundary self-consistency + honest graduations

**The bottleneck (measured live, P2 scan 2026-07-11):** the LLM score is non-deterministic — same input, **avg ~16-pt spread, max 60** — against a 10-pt near-miss band around threshold 60. **62 of 286 scores sit within ±16 of the cutoff**, so the whole shortlist boundary is a coin-flip; and the reassess **"graduation" badge fires on that noise** (15 measured "graduations" with an *unchanged* profile).

### Change 1 — boundary resample (root fix; `core/ingest.py`)
`_score_with_resample` scores once, and **only** when `abs(score − threshold) ≤ trigger_margin` (default **16**, both sides of the cut) re-scores to **N=3** total samples and keeps the **median sample** (a coherent `ScoreResult` — its narrative/subscores match its number, never averaged). Clearly-in / clearly-out or `N=1` → exactly **one** call. Wired into `score_gold` + `reassess`. `N`/margin are **module constants** (defaulted params) — **no new required `SearchSpec` field**, so no config-first break; `N=1` is byte-identical to today. The `Scorer` class stays pure. **Cost:** only ~62/286 boundary jobs get +2 calls (~pennies).

### Change 2 — honest graduations (rider; `core/notifier.py` + `core/ingest.py` + `core/ports.py`)
A "graduation" now requires the **profile actually changed** (prior score's `profile_hash` ≠ current), fixed on both the reassess side and the digest side (`ShortlistItem.prior_profile_changed`). A same-profile noise-crossing → no badge, folds to still-open/unchanged. (Change 1 already removes most false graduations by stabilizing boundary scores — this is belt-and-suspenders.)

**No migration, no Terraform/infra, no new dependency.**

### Squad trail
Investigator (P2 scan) → Surgeon → **Examiner: CLEAN PASS, zero blockers.** 396 unit tests green, ruff clean. Examiner verified median correctness, the cost-guard call-count, no-regression-when-disabled, and the profile-hash graduation logic (SQL compiles to standard Postgres; a live-smoke item over the Data API).

### ⚠️ Human decision (crucial tier — scoring semantics)
- **should-fix:** the resample tail vs the H-2 deadline margin — a boundary task can run up to N=3 sequential scoring calls with no mid-loop deadline check; `_DEADLINE_MARGIN_S=60s` was sized for one call, so a **full-set reassess** near the 15-min wall could overrun (dormant in daily incremental runs). Fix = a mid-resample deadline check, or widen the margin, or accept+document.
- **minors (deferrable):** a `human-override` event can shift the 2-event window → a contrived-ordering cosmetic false badge; the shadow code-total logs N× on a resampled posting (log noise only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added boundary resampling to improve scoring consistency for results near the threshold.
  * Graduation indicators now appear only when threshold crossings follow a profile change.
* **Bug Fixes**
  * Updated digest notifications so same-profile threshold crossings remain categorized as still open rather than new.
  * Improved reassessment tracking of prior profile state.
* **Tests**
  * Added coverage for boundary resampling, profile-change graduations, and notification classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->