### PR TITLE
feat(audit): full S3 audit persistence — every pipeline stage's results + run summary to S3 (U1)

### DIFF
--- a/src/jobfetcher/adapters/s3_audit.py
+++ b/src/jobfetcher/adapters/s3_audit.py
@@ -10,10 +10,13 @@ moto/mock client. The run context (`run_id`, `run_date`) is bound at constructio
 sites pass only records. No IAM/Terraform change: the Lambda role already grants `s3:PutObject`
 on the whole data bucket, so these new prefixes are already covered.
 
-**Non-fatal by contract:** every write goes through `_safe_put`, which logs a warning and returns
-`None` on ANY failure — an audit write can NEVER fail a pipeline run (the run's DB writes + email
-are independent). This mirrors the `notify` full-list-report guard, but at the store boundary, so
-every call site is inherently non-fatal.
+**Non-fatal by contract:** every write goes through `_guarded_put`, which wraps BOTH serialization
+and the S3 put and logs a warning + returns `None` on ANY failure — an audit write can NEVER fail
+a pipeline run (the run's DB writes + email are independent). This mirrors the `notify`
+full-list-report guard, but at the store boundary, so every call site is inherently non-fatal.
+(The callers build each record from an already-validated pydantic model via `model_dump(mode=
+"json")` — which cannot raise — so accumulation outside the guard is safe; the guard covers the
+batch serialize + write, where the realistic failures live.)
 
 **Batched:** one object per stage per run (JSONL — one record per line), so the audit costs a
 handful of PutObjects per run, not one per posting. Overwrite semantics — a re-run for the same

--- a/src/jobfetcher/adapters/s3_audit.py
+++ b/src/jobfetcher/adapters/s3_audit.py
@@ -1,0 +1,108 @@
+"""`S3AuditStore` — persists each pipeline stage's structured procedures + results to S3, so the
+full medallion (silver dissections, gold decisions, scores) **and** the per-run summary live in S3
+alongside Aurora — a replayable audit trail (v0.12.0). Today only the bronze RAW (`raw/…`) and the
+rendered report (`reports/…`) reach S3; the derived results were Aurora-only and the run summary
+lived only in the logs.
+
+Mirrors `S3RawStore`/`S3ReportStore`: the bucket comes from `$JOBFETCHER_DATA_BUCKET` (no default —
+a clear error if unset), boto3 uses the ambient IAM identity (no secrets here), tests inject a
+moto/mock client. The run context (`run_id`, `run_date`) is bound at construction so stage call
+sites pass only records. No IAM/Terraform change: the Lambda role already grants `s3:PutObject`
+on the whole data bucket, so these new prefixes are already covered.
+
+**Non-fatal by contract:** every write goes through `_safe_put`, which logs a warning and returns
+`None` on ANY failure — an audit write can NEVER fail a pipeline run (the run's DB writes + email
+are independent). This mirrors the `notify` full-list-report guard, but at the store boundary, so
+every call site is inherently non-fatal.
+
+**Batched:** one object per stage per run (JSONL — one record per line), so the audit costs a
+handful of PutObjects per run, not one per posting. Overwrite semantics — a re-run for the same
+`run_id` overwrites its own objects (like `reports/`, unlike immutable-bronze).
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import date
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+_BUCKET_ENV = "JOBFETCHER_DATA_BUCKET"
+
+
+class S3AuditStore:
+    """Persists stage records + the run summary to S3 under `silver/`, `gold/`, `scores/`, `runs/`
+    (keyed `{prefix}/{run_date}/{run_id}`). Every write is best-effort (non-fatal)."""
+
+    def __init__(
+        self, *, run_id: str, run_date: date, bucket: str | None = None, client: Any = None
+    ) -> None:
+        self._run_id = run_id
+        self._day = run_date.isoformat()
+        self._bucket = bucket or os.environ.get(_BUCKET_ENV) or ""
+        if not self._bucket.strip():
+            raise ValueError(
+                f"no S3 data bucket configured — set ${_BUCKET_ENV} or pass bucket="
+            )
+        if client is not None:
+            self._client = client
+        else:
+            import boto3  # lazy: tests inject a moto/mock client and need no real import here
+
+            self._client = boto3.client("s3")
+
+    # ------------------------------------------------------------------ stage writers (batched)
+    def put_silver(self, records: list[dict[str, Any]]) -> str | None:
+        """The silver dissections → `silver/{date}/{run_id}.jsonl` (one JSON per line)."""
+        return self._put_jsonl("silver", records)
+
+    def put_gold(self, records: list[dict[str, Any]]) -> str | None:
+        """The gold filter decisions → `gold/{date}/{run_id}.jsonl`."""
+        return self._put_jsonl("gold", records)
+
+    def put_scores(self, records: list[dict[str, Any]]) -> str | None:
+        """The score results → `scores/{date}/{run_id}.jsonl` (both score_gold and reassess)."""
+        return self._put_jsonl("scores", records)
+
+    def put_run_summary(self, summary: dict[str, Any]) -> str | None:
+        """The handler's run-summary dict → `runs/{date}/{run_id}.json` — the per-run procedure
+        record (statusCode, per-stage counts, partial, reassess graduations/deltas) that otherwise
+        survives only in the logs."""
+        key = f"runs/{self._day}/{self._run_id}.json"
+        return self._guarded_put(
+            key,
+            lambda: json.dumps(summary, ensure_ascii=False, indent=2, default=str).encode("utf-8"),
+            "application/json",
+        )
+
+    # ------------------------------------------------------------------ internals
+    def _put_jsonl(self, prefix: str, records: list[dict[str, Any]]) -> str | None:
+        """Batch `records` into one newline-delimited-JSON object. An **empty** batch writes
+        nothing (the run summary records the zero, so an absent object is unambiguous — an
+        empty-object write would falsely imply the stage ran with results)."""
+        if not records:
+            return None
+        key = f"{prefix}/{self._day}/{self._run_id}.jsonl"
+        return self._guarded_put(
+            key,
+            lambda: "\n".join(
+                json.dumps(r, ensure_ascii=False, default=str) for r in records
+            ).encode("utf-8"),
+            "application/x-ndjson",
+        )
+
+    def _guarded_put(self, key: str, make_body: "Any", content_type: str) -> str | None:
+        """The single non-fatal boundary: **serialize AND write** inside one guard, or log +
+        return `None` on ANY failure. Serialization is inside the guard on purpose — a stray
+        non-serializable value must be as non-fatal as an S3 error. An audit write must never
+        fail the pipeline run (mirrors the `notify` report guard)."""
+        try:
+            self._client.put_object(
+                Bucket=self._bucket, Key=key, Body=make_body(), ContentType=content_type
+            )
+            return key
+        except Exception as exc:  # noqa: BLE001 — audit is an enhancement; NEVER fail the run
+            log.warning("S3 audit write skipped (key=%s): %s", key, exc)
+            return None

--- a/src/jobfetcher/core/ingest.py
+++ b/src/jobfetcher/core/ingest.py
@@ -374,6 +374,9 @@ def apply_gold_filter(
             failed_open += 1
 
         if audit_store is not None:
+            # `likely_fit` = the strategy's verdict; `promoted` = whether it actually reached gold.
+            # They coincide in v0 (a fit is always promoted) but are distinct concepts recorded
+            # separately so the audit stays honest when they diverge (e.g. clustering at M2).
             # cluster_id == posting_id for a promoted candidate (v0 1:1 cluster); None if dropped.
             gold_records.append({
                 "posting_id": posting_id,

--- a/src/jobfetcher/core/ingest.py
+++ b/src/jobfetcher/core/ingest.py
@@ -26,6 +26,7 @@ from .report import render_full_list
 from .scorer import ScorerError, subscores_payload
 
 if TYPE_CHECKING:
+    from ..adapters.s3_audit import S3AuditStore
     from ..adapters.s3_raw import RawStore
     from ..adapters.s3_reports import ReportStore
     from .dissector import Dissector
@@ -243,6 +244,7 @@ def ingest(
     pipeline_version: str = "v0",
     max_workers: int = DEFAULT_MAX_WORKERS,
     deadline: Deadline | None = None,
+    audit_store: "S3AuditStore | None" = None,
 ) -> dict[str, int]:
     """End-to-end Step-4 run: fetch→bronze, then derive silver for each *distinct, new*
     posting. Returns a small summary of counts. `bronzed` == distinct ids landed this run;
@@ -294,6 +296,9 @@ def ingest(
             pipeline_version=pipeline_version,
         )
 
+    # S3 audit (v0.12.0): accumulate each landed silver record on the MAIN thread (next to the
+    # repo write — never on a worker), then write ONE batched JSONL after the join. Non-fatal.
+    silver_records: list[dict[str, Any]] = []
     if work:
         with ThreadPoolExecutor(max_workers=max_workers) as pool:
             futures = [pool.submit(_dissect_task, item) for item in work]
@@ -307,6 +312,14 @@ def ingest(
                     dissected, kwargs = outcome
                     repo.save_posting(dissected, **kwargs)  # main thread — the only writer
                     silvered += 1
+                    if audit_store is not None:
+                        silver_records.append({
+                            **dissected.model_dump(mode="json"),
+                            "posting_id": kwargs["posting_id"],
+                            "bronze_id": kwargs["bronze_id"],
+                        })
+    if audit_store is not None:
+        audit_store.put_silver(silver_records)
     if deferred:
         log.warning(
             "ingest deadline reached (run_id=%s): %d dissection(s) deferred to the next run",
@@ -331,6 +344,7 @@ def apply_gold_filter(
     strategy: "FilterStrategy",
     repo: "Repository",
     source: str = "jsearch",  # noqa: ARG001 — accepted for symmetry/future multi-source; unused in v0
+    audit_store: "S3AuditStore | None" = None,
 ) -> dict[str, int]:
     """Step-4b gold filter: load every silver posting → ask the `strategy` if it is a likely
     fit → for each fit, create its trivial **1:1 cluster** (cluster_id == posting_id), attach
@@ -349,6 +363,8 @@ def apply_gold_filter(
     gold = 0
     dropped = 0
     failed_open = 0
+    # S3 audit (v0.12.0): one decision record per candidate examined (fit or not). Non-fatal.
+    gold_records: list[dict[str, Any]] = []
     for posting_id, posting in candidates:
         try:
             likely_fit = strategy.filter(spec, profile, posting)
@@ -356,6 +372,15 @@ def apply_gold_filter(
             log.warning("gold filter failed open (include) for %s: %s", posting_id, exc)
             likely_fit = True
             failed_open += 1
+
+        if audit_store is not None:
+            # cluster_id == posting_id for a promoted candidate (v0 1:1 cluster); None if dropped.
+            gold_records.append({
+                "posting_id": posting_id,
+                "cluster_id": posting_id if likely_fit else None,
+                "likely_fit": likely_fit,
+                "promoted": likely_fit,
+            })
 
         if not likely_fit:
             dropped += 1
@@ -366,6 +391,9 @@ def apply_gold_filter(
         repo.set_posting_cluster(posting_id, posting_id)
         repo.mark_gold_candidate(posting_id)
         gold += 1
+
+    if audit_store is not None:
+        audit_store.put_gold(gold_records)
 
     summary = {"silver": len(candidates), "gold": gold, "dropped": dropped}
     if failed_open:
@@ -476,6 +504,7 @@ def score_gold(
     deadline: Deadline | None = None,
     resample_n: int = DEFAULT_RESAMPLE_N,
     resample_margin: int = DEFAULT_RESAMPLE_TRIGGER_MARGIN,
+    audit_store: "S3AuditStore | None" = None,
 ) -> dict[str, int]:
     """Step-5 scoring: load the candidate profile + its **runtime** threshold knobs, then for
     each gold candidate -> score it (LLM, boundary-resampled) -> derive its `fit_category` from
@@ -515,6 +544,8 @@ def score_gold(
     surfaced = 0
     failed = 0
     deferred = 0
+    # S3 audit (v0.12.0): one record per persisted score (main thread), batched after the join.
+    score_records: list[dict[str, Any]] = []
 
     def _score_task(candidate: tuple) -> Any:
         posting_id, _cluster_id, dissected = candidate
@@ -573,6 +604,15 @@ def score_gold(
                 scored += 1
                 if result.score >= threshold:
                     surfaced += 1
+                if audit_store is not None:
+                    score_records.append({
+                        "posting_id": posting_id,
+                        "cluster_id": cluster_id,
+                        "fit_category": fit_category,
+                        **result.model_dump(mode="json"),
+                    })
+    if audit_store is not None:
+        audit_store.put_scores(score_records)
     if deferred:
         log.warning(
             "scoring deadline reached (run_id=%s): %d candidate(s) deferred to the next run",
@@ -601,6 +641,7 @@ def reassess(
     resample_n: int = DEFAULT_RESAMPLE_N,
     resample_margin: int = DEFAULT_RESAMPLE_TRIGGER_MARGIN,
     max_age_days: int | None = None,
+    audit_store: "S3AuditStore | None" = None,
 ) -> dict[str, Any]:
     """Replay scoring over the already-scored postings against the **current** profile — no
     fetch, no gold (ADR-0023). The medallion's immutable-bronze → replay property: when the
@@ -645,6 +686,8 @@ def reassess(
     deferred = 0
     graduations: list[dict[str, Any]] = []
     deltas: list[int] = []  # |new − old| per successful reassess — the distribution input
+    # S3 audit (v0.12.0): one record per re-scored posting (main thread), batched after the join.
+    score_records: list[dict[str, Any]] = []
 
     def _rescore_task(target: tuple) -> Any:
         posting_id = target[0]
@@ -703,6 +746,14 @@ def reassess(
                 )
                 reassessed += 1
                 deltas.append(abs(result.score - old_score))
+                if audit_store is not None:
+                    score_records.append({
+                        "posting_id": posting_id,
+                        "cluster_id": cluster_id,
+                        "fit_category": new_cat,
+                        "previous_score": old_score,
+                        **result.model_dump(mode="json"),
+                    })
                 # A graduation is a crossing UP *caused by a profile change* — the prior score
                 # came from a DIFFERENT profile than this run's. A crossing under the SAME
                 # profile is LLM sampling noise (the boundary resample already suppresses most),
@@ -730,6 +781,8 @@ def reassess(
                     downgraded += 1
                 else:  # both sides equal, or a same-profile (noise) crossing
                     unchanged += 1
+    if audit_store is not None:
+        audit_store.put_scores(score_records)
     if deferred:
         log.warning(
             "reassess deadline reached (run_id=%s): %d posting(s) deferred to the next run",

--- a/src/jobfetcher/handlers/pipeline.py
+++ b/src/jobfetcher/handlers/pipeline.py
@@ -37,6 +37,7 @@ from ..adapters.filter_deterministic import DeterministicFilterStrategy
 from ..adapters.jsearch_source import JSearchSourceAdapter
 from ..adapters.llm_openai import OpenAICompatLlmClient
 from ..adapters.repository_postgres import PostgresRepository
+from ..adapters.s3_audit import S3AuditStore
 from ..adapters.s3_config import read_config_text
 from ..adapters.s3_raw import S3RawStore
 from ..adapters.s3_reports import S3ReportStore
@@ -268,6 +269,9 @@ def handler(event: dict[str, Any] | None = None, context: Any = None) -> dict[st
 
     try:
         env = dict(os.environ)
+        # Bound up-front (constructed below) so the outer `except` can persist the run summary
+        # even when a stage fails before the store is built. Stays None through smoke mode.
+        audit_store: S3AuditStore | None = None
 
         # --- smoke mode (deploy gate): prove the Lambda reaches the DB AND the schema is at
         # the head this code expects — with ZERO side effects. Runs BEFORE any config read or
@@ -349,6 +353,14 @@ def handler(event: dict[str, Any] | None = None, context: Any = None) -> dict[st
         source_adapter = JSearchSourceAdapter()
         raw_store = S3RawStore()
         report_store = S3ReportStore()  # B-1: same data bucket; the full-list report + presign
+        # v0.12.0: the full-audit store (silver/gold/scores/runs → S3). Even CONSTRUCTION is
+        # guarded — the whole audit trail is an enhancement that must NEVER fail the run (its
+        # methods are internally non-fatal too; $JOBFETCHER_DATA_BUCKET is set, same as above).
+        try:
+            audit_store = S3AuditStore(run_id=run_id, run_date=run_date)
+        except Exception as exc:  # noqa: BLE001 — audit is best-effort; never a run-fatal path
+            rlog.warning("S3 audit store unavailable — run continues without audit: %s", exc)
+            audit_store = None
         dissector = Dissector(
             OpenAICompatLlmClient(LlmConfig(model=_DISSECT_MODEL)), model_id=_DISSECT_MODEL
         )
@@ -373,15 +385,19 @@ def handler(event: dict[str, Any] | None = None, context: Any = None) -> dict[st
                 max_workers=max_workers,
                 deadline=deadline,
                 max_age_days=spec.reassess_max_age_days,
+                audit_store=audit_store,
             )
             rlog.info("mode=reassess done %s", reassess_report)
-            return {
+            reassess_summary = {
                 "statusCode": 200,
                 "run_id": run_id,
                 "run_date": run_date.isoformat(),
                 "mode": "reassess",
                 "reassess": reassess_report,
             }
+            if audit_store is not None:
+                audit_store.put_run_summary(reassess_summary)  # non-fatal
+            return reassess_summary
 
         # --- the pipeline, in sequence (each stage is idempotent via its own upserts) ---
         rlog.info("stage=ingest start run_date=%s", run_date.isoformat())
@@ -395,13 +411,15 @@ def handler(event: dict[str, Any] | None = None, context: Any = None) -> dict[st
             source=spec.source,
             max_workers=max_workers,
             deadline=deadline,
+            audit_store=audit_store,
         )
         rlog.info("stage=ingest done %s", ingest_counts)
 
         rlog.info("stage=gold start")
         db_profile = Profile.from_jsonb(repo.get_profile(user_id)["profile"])
         gold_counts = apply_gold_filter(
-            spec, db_profile, strategy=strategy, repo=repo, source=spec.source
+            spec, db_profile, strategy=strategy, repo=repo, source=spec.source,
+            audit_store=audit_store,
         )
         rlog.info("stage=gold done %s", gold_counts)
 
@@ -414,6 +432,7 @@ def handler(event: dict[str, Any] | None = None, context: Any = None) -> dict[st
             user_id=user_id,
             max_workers=max_workers,
             deadline=deadline,
+            audit_store=audit_store,
         )
         rlog.info("stage=score done %s", score_counts)
 
@@ -455,12 +474,15 @@ def handler(event: dict[str, Any] | None = None, context: Any = None) -> dict[st
 
     except Exception as exc:  # noqa: BLE001 — surface ANY stage failure as a retryable 500
         rlog.exception("pipeline failed: %s", exc)
-        return {
+        error_summary = {
             "statusCode": 500,
             "run_id": run_id,
             "run_date": run_date.isoformat(),
             "error": f"{type(exc).__name__}: {exc}",
         }
+        if audit_store is not None:
+            audit_store.put_run_summary(error_summary)  # non-fatal — the failed run's record
+        return error_summary
 
     summary = {
         "statusCode": 200,
@@ -472,5 +494,7 @@ def handler(event: dict[str, Any] | None = None, context: Any = None) -> dict[st
         "score": score_counts,
         "notify": notify_counts,
     }
+    if audit_store is not None:
+        audit_store.put_run_summary(summary)  # v0.12.0 — the per-run procedure record (non-fatal)
     rlog.info("pipeline done %s", summary)
     return summary

--- a/src/jobfetcher/handlers/pipeline.py
+++ b/src/jobfetcher/handlers/pipeline.py
@@ -268,10 +268,11 @@ def handler(event: dict[str, Any] | None = None, context: Any = None) -> dict[st
     rlog = logging.LoggerAdapter(log, {"run_id": run_id})
 
     try:
-        env = dict(os.environ)
-        # Bound up-front (constructed below) so the outer `except` can persist the run summary
-        # even when a stage fails before the store is built. Stays None through smoke mode.
+        # Bound as the FIRST statement (constructed for real below) so the outer `except` can
+        # persist the run summary even when a stage fails before the store is built — and can
+        # never hit UnboundLocalError. Stays None through smoke mode (no audit side effects).
         audit_store: S3AuditStore | None = None
+        env = dict(os.environ)
 
         # --- smoke mode (deploy gate): prove the Lambda reaches the DB AND the schema is at
         # the head this code expects — with ZERO side effects. Runs BEFORE any config read or

--- a/tests/test_integration_handler.py
+++ b/tests/test_integration_handler.py
@@ -222,6 +222,7 @@ def patched(monkeypatch, repo, db_url):
         ses = boto3.client("ses", region_name="us-east-1")
         ses.verify_email_identity(EmailAddress="from@jobfetcher.test")
 
+        from jobfetcher.adapters.s3_audit import S3AuditStore
         from jobfetcher.adapters.s3_raw import S3RawStore
         from jobfetcher.adapters.s3_reports import S3ReportStore
         from jobfetcher.adapters.ses_notifier import SesNotifier
@@ -232,6 +233,12 @@ def patched(monkeypatch, repo, db_url):
         monkeypatch.setattr(
             pipe, "S3ReportStore",
             lambda: S3ReportStore(bucket="jobfetcher-test-bucket", client=s3),
+        )
+        monkeypatch.setattr(
+            pipe, "S3AuditStore",
+            lambda *, run_id, run_date: S3AuditStore(
+                run_id=run_id, run_date=run_date, bucket="jobfetcher-test-bucket", client=s3
+            ),
         )
         monkeypatch.setattr(
             pipe, "SesNotifier", lambda: SesNotifier(sender="from@jobfetcher.test", client=ses)
@@ -292,6 +299,75 @@ def test_handler_end_to_end_then_idempotent(repo, patched, tmp_path):
     assert _count(repo, "score") == score1
     assert _count(repo, "run_log") == 1
     assert len(_sent_messages()) == 1  # STILL exactly one email — no duplicate
+
+
+def test_handler_persists_audit_medallion_to_s3(repo, patched, tmp_path):
+    """v0.12.0: every stage's structured results + the per-run summary also land in S3 — the
+    full audit medallion alongside Aurora. One batched object per stage per run."""
+    import boto3
+
+    _truncate(repo)
+    out = _invoke(tmp_path)
+    assert out["statusCode"] == 200 and out["score"]["scored"] == 2
+
+    s3 = boto3.client("s3", region_name="us-east-1")
+
+    def keys(prefix: str) -> list[str]:
+        resp = s3.list_objects_v2(Bucket="jobfetcher-test-bucket", Prefix=prefix)
+        return [o["Key"] for o in resp.get("Contents", [])]
+
+    def body(key: str) -> bytes:
+        return s3.get_object(Bucket="jobfetcher-test-bucket", Key=key)["Body"].read()
+
+    # each stage wrote its batched object + the run summary (mirrors the medallion in S3)
+    assert keys("silver/") and keys("gold/") and keys("scores/") and keys("runs/")
+
+    # the run summary IS the handler's returned procedure record (which lived only in logs before)
+    run_summary = json.loads(body(keys("runs/")[0]))
+    assert run_summary["statusCode"] == 200
+    assert run_summary["score"]["scored"] == 2 and run_summary["notify"]["sent"] == 1
+
+    # the scores object is JSONL — one line per scored posting, carrying the ScoreResult
+    score_lines = body(keys("scores/")[0]).decode("utf-8").splitlines()
+    assert len(score_lines) == 2
+    assert all(json.loads(line)["score"] == 90 for line in score_lines)
+    assert all(json.loads(line)["fit_category"] == "strong_fit" for line in score_lines)
+
+    # the gold object records a decision per candidate (both promoted here)
+    gold_lines = body(keys("gold/")[0]).decode("utf-8").splitlines()
+    assert len(gold_lines) == 2 and all(json.loads(line)["promoted"] for line in gold_lines)
+
+    # the silver object carries the dissected skills (the structured result, not just raw)
+    silver_lines = body(keys("silver/")[0]).decode("utf-8").splitlines()
+    assert len(silver_lines) == 2 and all("skills" in json.loads(line) for line in silver_lines)
+
+
+def test_handler_audit_failure_does_not_fail_run(repo, patched, tmp_path, monkeypatch):
+    """The audit trail is an enhancement — a totally broken S3 audit path must NEVER fail the
+    run: the pipeline still returns 200 and the digest still sends (the non-fatal guarantee,
+    end-to-end through the handler)."""
+    import jobfetcher.handlers.pipeline as pipe
+
+    from jobfetcher.adapters.s3_audit import S3AuditStore
+
+    class _BoomS3:
+        def put_object(self, **kw):  # noqa: ANN003, ANN201
+            raise RuntimeError("s3 audit is down")
+
+    monkeypatch.setattr(
+        pipe, "S3AuditStore",
+        lambda *, run_id, run_date: S3AuditStore(
+            run_id=run_id, run_date=run_date, bucket="b", client=_BoomS3()
+        ),
+    )
+
+    _truncate(repo)
+    out = _invoke(tmp_path)
+    assert out["statusCode"] == 200  # audit failures never fail the run
+    assert out["score"]["scored"] == 2
+    assert out["notify"]["sent"] == 1  # the digest still goes out
+    # and the real work still landed in Aurora despite the dead audit path
+    assert _count(repo, "score") == 2
 
 
 def test_handler_reads_config_from_s3(repo, patched, tmp_path):

--- a/tests/test_integration_handler.py
+++ b/tests/test_integration_handler.py
@@ -370,6 +370,24 @@ def test_handler_audit_failure_does_not_fail_run(repo, patched, tmp_path, monkey
     assert _count(repo, "score") == 2
 
 
+def test_handler_survives_audit_store_construction_failure(repo, patched, tmp_path, monkeypatch):
+    """Even the audit store's CONSTRUCTION is guarded — if the ctor raises (e.g. a missing bucket
+    in a misconfigured env), the run continues with no audit trail and still returns 200 + sends
+    the digest (belt-and-suspenders: the audit path can never fail the run, not even at setup)."""
+    import jobfetcher.handlers.pipeline as pipe
+
+    def _boom_ctor(*, run_id, run_date):  # noqa: ARG001
+        raise RuntimeError("audit store cannot initialize")
+
+    monkeypatch.setattr(pipe, "S3AuditStore", _boom_ctor)
+
+    _truncate(repo)
+    out = _invoke(tmp_path)
+    assert out["statusCode"] == 200
+    assert out["score"]["scored"] == 2
+    assert out["notify"]["sent"] == 1
+
+
 def test_handler_reads_config_from_s3(repo, patched, tmp_path):
     """ADR-0022: config is read from S3 at RUNTIME (not bundled). Put the two YAMLs in the
     (moto) bucket, point the env at `s3://` URIs, and the pipeline runs from S3 — the seam that
@@ -521,6 +539,29 @@ def test_handler_reassess_mode_replays_and_graduates(repo, patched, tmp_path, mo
 
     # no NEW bronze/posting rows were created (replay only re-scores; no fetch)
     assert _count(repo, "bronze_posting") == 2 and _count(repo, "posting") == 2
+
+    # v0.12.0 audit: the reassess re-scores also land in S3 (scores/ + the run summary), carrying
+    # previous_score — so the replay's procedures are auditable, not only the resulting DB state.
+    import boto3
+
+    s3 = boto3.client("s3", region_name="us-east-1")
+    score_keys = [
+        o["Key"] for o in
+        s3.list_objects_v2(Bucket="jobfetcher-test-bucket", Prefix="scores/").get("Contents", [])
+    ]
+    reassess_key = next(k for k in score_keys if "reassess1" in k)  # KeyError-safe: raises if absent
+    lines = (
+        s3.get_object(Bucket="jobfetcher-test-bucket", Key=reassess_key)["Body"]
+        .read().decode("utf-8").splitlines()
+    )
+    assert len(lines) == 2
+    assert all(json.loads(ln)["score"] == 90 and json.loads(ln)["previous_score"] == 60
+               for ln in lines)
+    run_keys = [
+        o["Key"] for o in
+        s3.list_objects_v2(Bucket="jobfetcher-test-bucket", Prefix="runs/").get("Contents", [])
+    ]
+    assert any("reassess1" in k for k in run_keys)  # the reassess run summary is persisted too
 
 
 def test_export_snapshot_from_db(repo, patched, tmp_path):

--- a/tests/test_s3_audit.py
+++ b/tests/test_s3_audit.py
@@ -1,0 +1,131 @@
+"""Isolated `S3AuditStore` unit tests (no AWS, no moto): the unset-bucket clear error, the key
+layout per stage, the batched-JSONL body shape, the run-summary object, the empty-batch no-op, and
+— the load-bearing guarantee — that ANY `put_object` failure is swallowed (logged, returns None,
+never propagates), so an audit write can never fail a pipeline run. Mirrors `test_s3_reports.py`."""
+from __future__ import annotations
+
+import json
+from datetime import date
+from typing import Any
+
+import pytest
+
+from jobfetcher.adapters.s3_audit import _BUCKET_ENV, S3AuditStore
+
+RUN_DATE = date(2026, 7, 11)
+
+
+class _FakeS3:
+    """Captures `put_object` calls."""
+
+    def __init__(self) -> None:
+        self.puts: list[dict[str, Any]] = []
+
+    def put_object(self, **kw: Any) -> dict:
+        self.puts.append(kw)
+        return {}
+
+
+class _ExplodingS3:
+    """Every `put_object` raises — models a transient S3 failure the audit must NOT propagate."""
+
+    def put_object(self, **kw: Any) -> dict:
+        raise RuntimeError("injected S3 failure")
+
+
+def _store(client: Any) -> S3AuditStore:
+    return S3AuditStore(run_id="r1", run_date=RUN_DATE, bucket="b", client=client)
+
+
+# --------------------------------------------------------------------------- construction
+def test_unset_bucket_raises_clear_error(monkeypatch):
+    # negative: no bucket env and no explicit bucket → a clear, actionable error.
+    monkeypatch.delenv(_BUCKET_ENV, raising=False)
+    with pytest.raises(ValueError, match=_BUCKET_ENV):
+        S3AuditStore(run_id="r1", run_date=RUN_DATE)
+
+
+def test_blank_bucket_env_raises(monkeypatch):
+    monkeypatch.setenv(_BUCKET_ENV, "   ")
+    with pytest.raises(ValueError, match=_BUCKET_ENV):
+        S3AuditStore(run_id="r1", run_date=RUN_DATE)
+
+
+# --------------------------------------------------------------------------- key layout + body
+def test_put_silver_key_layout_and_jsonl_body():
+    client = _FakeS3()
+    key = _store(client).put_silver([{"posting_id": "jsearch:1"}, {"posting_id": "jsearch:2"}])
+    assert key == "silver/2026-07-11/r1.jsonl"
+    assert len(client.puts) == 1
+    call = client.puts[0]
+    assert call["Bucket"] == "b"
+    assert call["Key"] == "silver/2026-07-11/r1.jsonl"
+    assert call["ContentType"] == "application/x-ndjson"
+    # body is newline-delimited JSON — one valid JSON object per line, N lines for N records
+    lines = call["Body"].decode("utf-8").split("\n")
+    assert len(lines) == 2
+    assert [json.loads(line)["posting_id"] for line in lines] == ["jsearch:1", "jsearch:2"]
+
+
+def test_put_gold_and_scores_key_layout():
+    client = _FakeS3()
+    store = _store(client)
+    assert store.put_gold([{"posting_id": "p"}]) == "gold/2026-07-11/r1.jsonl"
+    assert store.put_scores([{"posting_id": "p"}]) == "scores/2026-07-11/r1.jsonl"
+    assert [c["Key"] for c in client.puts] == [
+        "gold/2026-07-11/r1.jsonl", "scores/2026-07-11/r1.jsonl"
+    ]
+
+
+def test_put_run_summary_writes_indented_json_object():
+    client = _FakeS3()
+    summary = {"statusCode": 200, "run_id": "r1", "score": {"scored": 3}}
+    key = _store(client).put_run_summary(summary)
+    assert key == "runs/2026-07-11/r1.json"
+    call = client.puts[0]
+    assert call["Key"] == "runs/2026-07-11/r1.json"
+    assert call["ContentType"] == "application/json"
+    assert json.loads(call["Body"].decode("utf-8")) == summary  # round-trips
+
+
+def test_empty_batch_writes_nothing():
+    # an empty stage → NO object (the run summary records the zero; an empty object would lie).
+    client = _FakeS3()
+    store = _store(client)
+    assert store.put_silver([]) is None
+    assert store.put_gold([]) is None
+    assert store.put_scores([]) is None
+    assert client.puts == []
+
+
+# --------------------------------------------------------------------------- the non-fatal guard
+def test_put_failure_is_swallowed_not_propagated(caplog):
+    # THE guarantee: a put_object that raises must NOT propagate — it logs + returns None, so an
+    # audit write can never fail the pipeline run. Covers the JSONL path and the run-summary path.
+    store = _store(_ExplodingS3())
+    assert store.put_silver([{"a": 1}]) is None
+    assert store.put_scores([{"a": 1}]) is None
+    assert store.put_run_summary({"statusCode": 500}) is None
+    # and it logged a warning for each (observability without failure)
+    assert sum("audit write skipped" in r.message for r in caplog.records) >= 1
+
+
+def test_serialization_failure_is_swallowed():
+    # serialization is INSIDE the guard: a record json.dumps can't encode (a circular ref, which
+    # even default=str can't rescue) must NOT propagate — logged, returns None, nothing written.
+    client = _FakeS3()
+    store = _store(client)
+    circular: dict[str, Any] = {}
+    circular["self"] = circular
+    assert store.put_scores([circular]) is None
+    assert client.puts == []  # never reached put_object; the run is unaffected
+
+
+def test_non_json_native_values_serialize_via_default():
+    # ScoreResult/DissectedPosting dumps use model_dump(mode="json"), but default=str is the
+    # belt-and-suspenders for any stray non-JSON-native value — it must not raise.
+    client = _FakeS3()
+    key = _store(client).put_scores([{"posting_id": "p", "when": date(2026, 7, 11)}])
+    assert key is not None
+    line = json.loads(client.puts[0]["Body"].decode("utf-8"))
+    assert line["when"] == "2026-07-11"


### PR DESCRIPTION
**v0.12.0 · Unit U1** — the first of two units (U2 = the local control panel follows).

## What
Today only the bronze raw JSON (`raw/…`) and the rendered HTML report (`reports/…`) reach S3; the derived results (silver dissections, gold decisions, scores) live only in Aurora, and the per-run summary lives only in the logs. This adds the **full audit medallion to S3** alongside Aurora.

- **New `adapters/s3_audit.py` → `S3AuditStore`** (mirrors `s3_raw`/`s3_reports`). Batched JSONL per stage per run:
  - `silver/{run_date}/{run_id}.jsonl` — one `DissectedPosting` per line
  - `gold/{run_date}/{run_id}.jsonl` — one filter decision per candidate
  - `scores/{run_date}/{run_id}.jsonl` — one `ScoreResult` per line (score_gold **and** reassess)
  - `runs/{run_date}/{run_id}.json` — the handler's run-summary dict (previously logs-only)
- **Non-fatal by contract:** serialize + put run inside a single `_guarded_put` — any failure logs a warning and returns `None`, so an audit write can **NEVER** fail a run (mirrors the `notify` report guard). Even the store's construction is guarded in the handler.
- **H-2 concurrency preserved:** records accumulate on the **main thread** (next to the repo write, after the ThreadPoolExecutor join) — never on a worker.
- **Additive:** four `audit_store=None` params on `ingest`/`gold`/`score`/`reassess` default to byte-for-byte today. **Smoke mode writes nothing.**

## No migration, no IAM/Terraform change
The Lambda role already grants `s3:PutObject` bucket-wide; `$JOBFETCHER_DATA_BUCKET` is already set. `alembic head` stays `0006_subscores`. No new dependency.

## Tests
- `tests/test_s3_audit.py` — key layout, JSONL body, run-summary shape, empty-batch no-op, and the **non-fatal guarantees** (S3-put failure *and* serialization failure both swallowed).
- Integration — the audit medallion lands in S3 after a run; a **broken audit path still returns 200 + sends the digest**; the audit store's **constructor** raising is survived; the **reassess** audit path lands `scores/` (carrying `previous_score`) + the run summary.
- 406 unit green locally, ruff clean. Integration validates in CI (Postgres).

## Review
Independent adversarial Examiner (fresh context) → **CLEAN PASS**, no blockers; all six invariants (non-fatal, concurrency, smoke-writes-nothing, additive-when-None, record correctness, empty-batch) confirmed. Minors + test gaps applied in the second commit.

**Severity: CRUCIAL** (touches the pipeline + deploys) — the deploy is a human checkpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional S3 audit trails for pipeline stages and run summaries.
  * Records silver, gold, scoring, and reassessment results in structured formats.
  * Captures successful and failed run summaries for later review.

* **Reliability**
  * Audit-storage or S3 write failures no longer interrupt pipeline execution.
  * Added coverage for audit persistence, configuration errors, serialization, and failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->