### PR TITLE
feat(panel): local Streamlit control panel — browse/curate/config (U2)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,9 @@ dev = ["pytest>=7", "pytest-cov>=4", "ruff>=0.4", "testcontainers[postgres]>=4",
 # Not a runtime dep — the recommended viewer for the `scripts/export.py` snapshot (ADR-0024):
 #   pip install -e '.[query]' && datasette export/jobs.sqlite
 query = ["datasette>=1"]
+# Not a runtime dep — the local operator control panel (ADR-0033), NEVER bundled in the Lambda:
+#   pip install -e '.[panel]' && streamlit run scripts/panel.py
+panel = ["streamlit>=1.36"]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/scripts/panel.py
+++ b/scripts/panel.py
@@ -30,7 +30,6 @@ import export  # noqa: E402 — read_data(): the flat jobs table + supporting ta
 import push_config  # noqa: E402 — validate_config_text + push_config_text + _resolve_bucket
 import track  # noqa: E402 — apply_override + the DB-URL resolver, reused verbatim
 from jobfetcher.core.models import APPLICATION_STATUSES  # noqa: E402
-from jobfetcher.core.ports import RepositoryError  # noqa: E402
 from jobfetcher.core.search_spec import (  # noqa: E402
     DatePosted,
     EmploymentType,
@@ -115,7 +114,7 @@ with tab_curate:
                     f"(was {r['previous_score']})"
                 )
                 _load_jobs.clear()  # refresh the browse grid on the next render
-            except RepositoryError as exc:
+            except Exception as exc:  # noqa: BLE001 — show any error in the UI, never a stack trace
                 st.error(str(exc))
 
     st.divider()
@@ -134,7 +133,7 @@ with tab_curate:
                 )
                 st.success(f"'{out_status}' recorded for {out_pid.strip()}")
                 _load_jobs.clear()
-            except RepositoryError as exc:
+            except Exception as exc:  # noqa: BLE001 — show any error in the UI, never a stack trace
                 st.error(str(exc))
 
 # --------------------------------------------------------------------------- Config

--- a/scripts/panel.py
+++ b/scripts/panel.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""panel.py — a LOCAL operator control panel (Streamlit) for JobFetcher (ADR-0033).
+
+    pip install -e '.[panel]'
+    streamlit run scripts/panel.py
+
+Three tabs, all against the LIVE Aurora + S3 (nothing hosted, no auth — a personal tool):
+  • Browse — every scored job, filter/search/sort (reuses scripts/export.py::read_data).
+  • Curate — override a score / record an outcome (reuses scripts/track.py's write paths).
+  • Config — edit the search params in a form → validate → push to S3 (reuses push_config).
+
+NEVER bundled in the Lambda (streamlit is the optional `[panel]` extra). The panel reuses the
+EXACT validated write paths the CLIs use, so it can never do anything the CLIs couldn't — a bad
+config edit is blocked before S3, and every curation goes through the same append-only lineage.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import streamlit as st
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+for _p in (ROOT / "src", ROOT / "scripts"):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+import export  # noqa: E402 — read_data(): the flat jobs table + supporting tables
+import push_config  # noqa: E402 — validate_config_text + push_config_text + _resolve_bucket
+import track  # noqa: E402 — apply_override + the DB-URL resolver, reused verbatim
+from jobfetcher.core.models import APPLICATION_STATUSES  # noqa: E402
+from jobfetcher.core.ports import RepositoryError  # noqa: E402
+from jobfetcher.core.search_spec import (  # noqa: E402
+    DatePosted,
+    EmploymentType,
+    RemoteMode,
+    SearchSpec,
+)
+from jobfetcher.db.engine import make_engine, wait_for_db_resume  # noqa: E402
+
+CONFIG_LOCAL = ROOT / "config" / "search_config.local.yml"
+CONFIG_S3_KEY = "config/search_config.yml"
+
+st.set_page_config(page_title="JobFetcher — Control Panel", layout="wide")
+
+
+@st.cache_resource
+def _engine_and_repo():
+    """One engine + repo per session (cached). Waits out Aurora's scale-to-0 resume once."""
+    from jobfetcher.adapters.repository_postgres import PostgresRepository
+
+    engine = make_engine(track._resolve_db_url())
+    with st.spinner("Connecting to Aurora (it may be resuming from scale-to-0)…"):
+        wait_for_db_resume(engine)
+    return engine, PostgresRepository.from_engine(engine)
+
+
+@st.cache_data(ttl=60)
+def _load_jobs() -> list[dict]:
+    """The flat `jobs` table (all scored postings) — reuses export.py's SELECTs. Cached for
+    60s; any curation clears the cache so the grid refreshes."""
+    engine, _ = _engine_and_repo()
+    return export.read_data(engine)["jobs"]
+
+
+st.title("JobFetcher — Control Panel")
+st.caption("A local operator view of the live pipeline data. Reuses the CLI write paths.")
+tab_browse, tab_curate, tab_config = st.tabs(["📋 Browse", "✏️ Curate", "⚙️ Config"])
+
+# --------------------------------------------------------------------------- Browse
+with tab_browse:
+    try:
+        jobs = _load_jobs()
+    except Exception as exc:  # noqa: BLE001 — a DB/connection error shows in the UI, not a stack trace
+        st.error(f"Could not load jobs: {exc}")
+        jobs = []
+    if jobs:
+        q = st.text_input("Search (title / company / location)")
+        c1, c2, c3 = st.columns(3)
+        cats = sorted({j["fit_category"] for j in jobs if j.get("fit_category")})
+        countries = sorted({j["country"] for j in jobs if j.get("country")})
+        cat_sel = c1.multiselect("Fit category", cats)
+        country_sel = c2.multiselect("Country", countries)
+        min_score = c3.slider("Min score", 0, 100, 0)
+
+        def _keep(j: dict) -> bool:
+            hay = f"{j.get('normalized_title', '')} {j.get('company', '')} {j.get('location', '')}"
+            return (
+                (not q or q.lower() in hay.lower())
+                and (not cat_sel or j.get("fit_category") in cat_sel)
+                and (not country_sel or j.get("country") in country_sel)
+                and (j.get("score") or 0) >= min_score
+            )
+
+        rows = [j for j in jobs if _keep(j)]
+        st.caption(f"{len(rows)} of {len(jobs)} scored jobs")
+        st.dataframe(rows, use_container_width=True, hide_index=True)
+
+# --------------------------------------------------------------------------- Curate
+with tab_curate:
+    st.subheader("Override a score")
+    st.caption("Records a human score override + a `human-override` lineage event (append-only).")
+    ov_pid = st.text_input("Posting id", key="ov_pid")
+    ov_score = st.number_input("New score (0-100)", min_value=0, max_value=100, value=60, key="ov")
+    if st.button("Apply override", type="primary"):
+        if not ov_pid.strip():
+            st.warning("Enter a posting id.")
+        else:
+            try:
+                engine, repo = _engine_and_repo()
+                r = track.apply_override(engine, repo, posting_id=ov_pid.strip(), score=int(ov_score))
+                st.success(
+                    f"Override {r['score']} ({r['fit_category']}) → {r['label']} "
+                    f"(was {r['previous_score']})"
+                )
+                _load_jobs.clear()  # refresh the browse grid on the next render
+            except RepositoryError as exc:
+                st.error(str(exc))
+
+    st.divider()
+    st.subheader("Record an outcome")
+    out_pid = st.text_input("Posting id", key="out_pid")
+    out_status = st.selectbox("Status", list(APPLICATION_STATUSES))
+    out_note = st.text_input("Note (optional)", key="out_note")
+    if st.button("Record outcome", type="primary"):
+        if not out_pid.strip():
+            st.warning("Enter a posting id.")
+        else:
+            try:
+                _, repo = _engine_and_repo()
+                repo.track_application_event(
+                    posting_id=out_pid.strip(), status=out_status, note=out_note or None
+                )
+                st.success(f"'{out_status}' recorded for {out_pid.strip()}")
+                _load_jobs.clear()
+            except RepositoryError as exc:
+                st.error(str(exc))
+
+# --------------------------------------------------------------------------- Config
+with tab_config:
+    st.subheader("Search settings")
+    st.caption("Edit → validate → push to S3. The next pipeline run uses it (no redeploy).")
+    if not CONFIG_LOCAL.exists():
+        st.warning(
+            f"No {CONFIG_LOCAL.name} yet — copy `config/search_config.sample.yml` to it first."
+        )
+    else:
+        # Start from the FULL current spec so the required fields not shown here (source /
+        # secret_name / aws_region / language / states / budget / age bounds) are preserved —
+        # the all-required SearchSpec contract holds on save.
+        d = SearchSpec.from_yaml(str(CONFIG_LOCAL)).model_dump(mode="json")
+        tgt = d["targeting"]
+        c1, c2, c3 = st.columns(3)
+        threshold = c1.number_input("Threshold", 0, 100, int(d["threshold"]))
+        hard_floor = c2.number_input("Hard floor", 0, 100, int(d["hard_floor"]))
+        near_miss = c3.number_input("Near-miss band", 0, 100, int(d["near_miss_band"]))
+        titles = st.text_area("Job titles (one per line)", "\n".join(tgt["job_titles"]))
+        countries = st.text_input("Countries (comma-separated ISO2)", ", ".join(tgt["countries"]))
+        cities = st.text_input("Cities (comma-separated, optional)", ", ".join(tgt["cities"]))
+        cc1, cc2 = st.columns(2)
+        dp_opts = [e.value for e in DatePosted]
+        rm_opts = [e.value for e in RemoteMode]
+        date_posted = cc1.selectbox("Date posted", dp_opts, index=dp_opts.index(d["date_posted"]))
+        remote = cc2.selectbox("Remote", rm_opts, index=rm_opts.index(d["remote"]))
+        emp = st.multiselect(
+            "Employment types", [e.value for e in EmploymentType], d["employment_types"]
+        )
+
+        if st.button("Validate + push to S3", type="primary"):
+            new = dict(d)
+            new["threshold"] = int(threshold)
+            new["hard_floor"] = int(hard_floor)
+            new["near_miss_band"] = int(near_miss)
+            new["targeting"] = {
+                **tgt,
+                "job_titles": [t.strip() for t in titles.splitlines() if t.strip()],
+                "countries": [c.strip().lower() for c in countries.split(",") if c.strip()],
+                "cities": [c.strip() for c in cities.split(",") if c.strip()],
+            }
+            new["date_posted"] = date_posted
+            new["remote"] = remote
+            new["employment_types"] = emp
+            text = yaml.safe_dump(new, sort_keys=False, allow_unicode=True)
+            # THE gate: validate the full spec before anything is written; a bad edit blocks here.
+            try:
+                push_config.validate_config_text(text, SearchSpec)
+            except Exception as exc:  # noqa: BLE001 — a ValidationError shows in the UI, not saved
+                st.error(f"Invalid config — nothing saved: {exc}")
+            else:
+                try:
+                    CONFIG_LOCAL.write_text(text, encoding="utf-8")  # local file stays the source
+                    bucket = push_config._resolve_bucket(None)  # env / terraform output
+                    push_config.push_config_text(bucket=bucket, key=CONFIG_S3_KEY, text=text)
+                    st.success(
+                        f"Saved locally + pushed to s3://{bucket}/{CONFIG_S3_KEY} — the next "
+                        "run uses it (no redeploy)."
+                    )
+                except SystemExit as exc:  # _resolve_bucket exits if no bucket is configured
+                    st.error(f"Saved locally, but no S3 bucket to push to: {exc}")
+                except Exception as exc:  # noqa: BLE001
+                    st.error(f"Saved locally, but the S3 push failed: {exc}")

--- a/scripts/push_config.py
+++ b/scripts/push_config.py
@@ -19,6 +19,7 @@ import os
 import subprocess
 import sys
 from pathlib import Path
+from typing import Any
 
 # Repo root + the src/ package (so this runs without an editable install).
 ROOT = Path(__file__).resolve().parents[1]
@@ -56,6 +57,28 @@ def _resolve_bucket(explicit: str | None) -> str:
     )
 
 
+# --------------------------------------------------------------------------- reusable core
+# Extracted so the control panel's config form (scripts/panel.py) shares the EXACT validate +
+# upload path — a bad edit can never reach S3 from either surface (one validation, one writer).
+def validate_config_text(text: str, model: type) -> None:
+    """Validate config YAML `text` against its Pydantic contract (`SearchSpec`/`Profile`).
+    Raises the model's `ValidationError` (or a YAML error) on anything invalid — the caller
+    surfaces it. This is THE gate: never upload config that fails to load."""
+    model.from_yaml_text(text)
+
+
+def push_config_text(*, bucket: str, key: str, text: str, client: Any = None) -> None:
+    """Upload config `text` to `s3://bucket/key` (the caller validates first). `client` is
+    injectable for tests (a moto/fake S3); else a real boto3 client is built lazily."""
+    if client is None:
+        import boto3
+
+        client = boto3.client("s3")
+    client.put_object(
+        Bucket=bucket, Key=key, Body=text.encode("utf-8"), ContentType="application/x-yaml"
+    )
+
+
 def main() -> None:
     ap = argparse.ArgumentParser(description="Push local config YAMLs to S3 (no redeploy).")
     ap.add_argument("--bucket", help="S3 data bucket (else $JOBFETCHER_DATA_BUCKET / terraform).")
@@ -66,22 +89,15 @@ def main() -> None:
         if not path.exists():
             sys.exit(f"missing {path} — seed it from {path.name.replace('.local.', '.sample.')}")
         try:
-            model.from_yaml_text(path.read_text(encoding="utf-8"))
+            validate_config_text(path.read_text(encoding="utf-8"), model)
         except Exception as exc:  # noqa: BLE001 — surface the validation error as a clean exit
             sys.exit(f"INVALID {path.name}: {exc}")
     print("[1/2] validated: search_config.local.yml + profile.local.yml")
 
-    # 2) upload.
+    # 2) upload (the shared writer).
     bucket = _resolve_bucket(args.bucket)
-    import boto3
-
-    s3 = boto3.client("s3")
     for path, key, _model in _UPLOADS:
-        s3.put_object(
-            Bucket=bucket, Key=key,
-            Body=path.read_text(encoding="utf-8").encode("utf-8"),
-            ContentType="application/x-yaml",
-        )
+        push_config_text(bucket=bucket, key=key, text=path.read_text(encoding="utf-8"))
         print(f"[2/2] uploaded {path.name} -> s3://{bucket}/{key}")
     print("done — the next pipeline run will use these settings (no redeploy needed).")
 

--- a/scripts/track.py
+++ b/scripts/track.py
@@ -198,17 +198,27 @@ def cmd_events(engine, *, posting_id: str) -> None:
         print(f"  {ev['noted_at']}  {ev['status']}{note}")
 
 
-def cmd_override(engine, repo, *, posting_id: str, score: int) -> None:
+def apply_override(engine, repo, *, posting_id: str, score: int) -> dict[str, Any]:
+    """The pure override path — reused by the `override` CLI command AND the control panel
+    (scripts/panel.py). Looks up the posting → its cluster + current score → the profile's
+    scoring context → derives `fit_category` from the runtime knobs (VG8) → `set_score_override`
+    (updates `score.score_override` + appends a `human-override` `score_event`, ADR-0026).
+
+    Raises `RepositoryError` on any precondition failure (no posting / no cluster / no score /
+    no profile row) — the caller decides how to surface it (the CLI `main()` turns it into a
+    stderr message + exit 1; the panel shows it in the UI). Returns a small result dict to render."""
     row = _posting_row(engine, posting_id)
     if row is None:
-        _fail(f"no posting {posting_id!r} — nothing written")
+        raise RepositoryError(f"no posting {posting_id!r} — nothing written")
     if row["cluster_id"] is None:
-        _fail(f"posting {posting_id!r} has no cluster yet — only scored postings can be overridden")
+        raise RepositoryError(
+            f"posting {posting_id!r} has no cluster yet — only scored postings can be overridden"
+        )
     score_rows = _fetch(
         engine, "SELECT score FROM score WHERE cluster_id = :c", {"c": row["cluster_id"]}
     )
     if not score_rows:
-        _fail(f"posting {posting_id!r} has no score row yet — nothing to override")
+        raise RepositoryError(f"posting {posting_id!r} has no score row yet — nothing to override")
     previous_score = score_rows[0]["score"]
     prof_rows = _fetch(
         engine,
@@ -230,9 +240,21 @@ def cmd_override(engine, repo, *, posting_id: str, score: int) -> None:
         profile_hash=profile_hash,
         previous_score=previous_score,
     )
+    return {
+        "posting_id": posting_id,
+        "label": _label(row),
+        "score": score,
+        "fit_category": fit_category,
+        "previous_score": previous_score,
+    }
+
+
+def cmd_override(engine, repo, *, posting_id: str, score: int) -> None:
+    # RepositoryError (a precondition failure or a DB error) propagates to main()'s handler.
+    r = apply_override(engine, repo, posting_id=posting_id, score=score)
     print(
-        f"  override {score} ({fit_category}) recorded for {posting_id}: {_label(row)}"
-        f"  (was {previous_score})"
+        f"  override {r['score']} ({r['fit_category']}) recorded for {r['posting_id']}: "
+        f"{r['label']}  (was {r['previous_score']})"
     )
 
 

--- a/tests/test_push_config.py
+++ b/tests/test_push_config.py
@@ -1,0 +1,56 @@
+"""Unit tests for the reusable config functions the control panel (scripts/panel.py) shares
+with the CLI (scripts/push_config.py): `validate_config_text` is THE gate (a bad edit never
+reaches S3), and `push_config_text` is the shared writer. The panel carries no separate
+validation path — these functions do, so they are unit-tested here."""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from jobfetcher.core.search_spec import SearchSpec
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# load the standalone script as a module (same harness as test_track.py / test_export.py)
+_spec = importlib.util.spec_from_file_location(
+    "push_config", ROOT / "scripts" / "push_config.py"
+)
+push_config = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(push_config)
+
+
+class _FakeS3:
+    def __init__(self) -> None:
+        self.puts: list[dict[str, Any]] = []
+
+    def put_object(self, **kw: Any) -> dict:
+        self.puts.append(kw)
+        return {}
+
+
+def test_validate_config_text_accepts_the_valid_sample():
+    # the committed sample is the complete, valid template — it must pass the gate.
+    text = (ROOT / "config" / "search_config.sample.yml").read_text(encoding="utf-8")
+    push_config.validate_config_text(text, SearchSpec)  # no raise
+
+
+def test_validate_config_text_rejects_an_incomplete_config():
+    # negative: the all-required contract — a config missing fields fails LOUDLY (never uploaded).
+    with pytest.raises(Exception):  # noqa: B017, PT011 — pydantic ValidationError (or a YAML error)
+        push_config.validate_config_text("threshold: 60\n", SearchSpec)
+
+
+def test_push_config_text_uploads_via_injected_client():
+    client = _FakeS3()
+    push_config.push_config_text(
+        bucket="b", key="config/search_config.yml", text="x: 1\n", client=client
+    )
+    assert len(client.puts) == 1
+    call = client.puts[0]
+    assert call["Bucket"] == "b"
+    assert call["Key"] == "config/search_config.yml"
+    assert call["Body"] == b"x: 1\n"
+    assert call["ContentType"] == "application/x-yaml"

--- a/tests/test_track.py
+++ b/tests/test_track.py
@@ -139,3 +139,62 @@ def test_profile_context_missing_row_is_loud():
     # negative: no profile row → RepositoryError (main() turns it into stderr + exit 1).
     with pytest.raises(RepositoryError, match="no profile row"):
         track._profile_context(None)
+
+
+# --------------------------------------------------------------------------- apply_override (U2)
+# The pure override path extracted for the control panel to reuse (scripts/panel.py). It carries
+# the correctness (the CLI + the panel are thin callers), so it is unit-tested here.
+class _CaptureRepo:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    def set_score_override(self, **kw) -> None:
+        self.calls.append(kw)
+
+
+def _override_fetch(*, with_score: bool = True, with_profile: bool = True):
+    """A scripted `_fetch` returning the posting row, then the score row, then the profile row."""
+    def _f(engine, sql, params=None):  # noqa: ARG001
+        if "FROM posting" in sql:
+            return [{
+                "posting_id": "p1", "cluster_id": "c1",
+                "title": "Data Engineer", "normalized_title": "Data Engineer", "company": "Acme",
+            }]
+        if "FROM score" in sql:
+            return [{"score": 55}] if with_score else []
+        if "FROM profile" in sql:
+            return [{"profile_hash": "ph", "threshold": 60, "hard_floor": 50,
+                     "near_miss_band": 10}] if with_profile else []
+        return []
+    return _f
+
+
+def test_apply_override_reuses_the_lineage_write_path(monkeypatch):
+    # a valid override → set_score_override called once with the derived fit_category + old score
+    monkeypatch.setattr(track, "_fetch", _override_fetch())
+    repo = _CaptureRepo()
+    r = track.apply_override(object(), repo, posting_id="p1", score=82)
+    assert (r["score"], r["previous_score"], r["fit_category"]) == (82, 55, "strong_fit")
+    assert "Data Engineer — Acme" in r["label"]
+    assert len(repo.calls) == 1
+    call = repo.calls[0]
+    assert call["cluster_id"] == "c1" and call["score_override"] == 82
+    assert call["fit_category"] == "strong_fit" and call["previous_score"] == 55
+
+
+def test_apply_override_unknown_posting_raises(monkeypatch):
+    # negative: no posting → RepositoryError (the panel shows it; the CLI exits 1) — nothing written
+    monkeypatch.setattr(track, "_fetch", lambda *a, **k: [])
+    repo = _CaptureRepo()
+    with pytest.raises(RepositoryError, match="no posting"):
+        track.apply_override(object(), repo, posting_id="nope", score=50)
+    assert repo.calls == []
+
+
+def test_apply_override_unscored_posting_raises(monkeypatch):
+    # negative: the posting has a cluster but no score row yet → nothing to override
+    monkeypatch.setattr(track, "_fetch", _override_fetch(with_score=False))
+    repo = _CaptureRepo()
+    with pytest.raises(RepositoryError, match="no score row"):
+        track.apply_override(object(), repo, posting_id="p1", score=50)
+    assert repo.calls == []

--- a/tests/test_track.py
+++ b/tests/test_track.py
@@ -198,3 +198,26 @@ def test_apply_override_unscored_posting_raises(monkeypatch):
     with pytest.raises(RepositoryError, match="no score row"):
         track.apply_override(object(), repo, posting_id="p1", score=50)
     assert repo.calls == []
+
+
+def test_apply_override_uncluster_posting_raises(monkeypatch):
+    # negative: a silver-only posting (no cluster yet) can't be overridden — only scored ones
+    def _f(engine, sql, params=None):  # noqa: ARG001
+        if "FROM posting" in sql:
+            return [{"posting_id": "p1", "cluster_id": None,
+                     "title": "t", "normalized_title": "t", "company": "c"}]
+        return []
+    monkeypatch.setattr(track, "_fetch", _f)
+    repo = _CaptureRepo()
+    with pytest.raises(RepositoryError, match="no cluster"):
+        track.apply_override(object(), repo, posting_id="p1", score=50)
+    assert repo.calls == []
+
+
+def test_cmd_override_wrapper_prints_the_success_line(monkeypatch, capsys):
+    # the thin CLI wrapper still prints the identical success line (byte-for-byte with the old
+    # cmd_override — the double space before "(was …)" is intentional and preserved).
+    monkeypatch.setattr(track, "_fetch", _override_fetch())
+    track.cmd_override(object(), _CaptureRepo(), posting_id="p1", score=82)
+    out = capsys.readouterr().out
+    assert "override 82 (strong_fit) recorded for p1: Data Engineer — Acme  (was 55)" in out


### PR DESCRIPTION
**v0.12.0 · Unit U2** — the second unit (U1 = full S3 audit persistence, already merged + deployed). Completes v0.12.0.

## What
A **local** operator control panel (`streamlit run scripts/panel.py`) — nothing hosted, no auth, no deploy. Three tabs, all against the live Aurora + S3:
- **Browse** — every scored job, filter/search/sort (reuses `scripts/export.py::read_data` + `wait_for_db_resume`).
- **Curate** — override a score / record an outcome, reusing the **extracted** `track.apply_override` + `repo.track_application_event` (the same append-only lineage paths as `track.py` — nothing new can be written).
- **Config** — edit the search params in a form → **validate → push to S3**, reusing `push_config`'s validate + upload so a bad edit can never reach S3.

## Behavior-preserving extractions (the CLIs stay thin wrappers)
- `track.py`: `apply_override(engine, repo, *, posting_id, score)` — the override path, now raising `RepositoryError` (the CLI's `main()` still turns it into stderr + exit 1, byte-identical).
- `push_config.py`: `validate_config_text` + `push_config_text` — the shared validate + writer.

## No deploy, no migration, no infra, no runtime dep
`streamlit` is an optional `[panel]` extra (like `[query]`/datasette) — **never** in the Lambda zip (`build_lambda.py` copies only `src/jobfetcher` with an explicit `RUNTIME_DEPS`).

## Tests
- `apply_override`: valid write + no-posting / no-cluster / no-score negatives; the `cmd_override` wrapper still prints the identical success line.
- `validate_config_text` / `push_config_text`: the valid sample passes, an incomplete config is rejected (never uploaded), the writer uploads via an injected client.
- 414 unit green, ruff clean. The panel UI is manual/smoke (`pip install -e '.[panel]'` → drive it locally).

## Review
Independent adversarial Examiner (fresh context) → **CLEAN PASS**, no blockers; all six verifications confirmed (behavior preservation of the live-write extraction, the all-required config contract preserved through the form, `validate_config_text` is the genuine gate, no Lambda coupling, the `_fetch` monkeypatch seam intact, safe panel import mechanics). Two minors applied (curate-tab error handling + wrapper tests).

**Severity: NON-CRUCIAL** (local tool, no deploy, no schema/infra/dep). On merge, main has both v0.12.0 units → tag `v0.12.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a local operator control panel for browsing jobs, filtering results, curating scores, recording application outcomes, and editing search configuration.
  * Added optional support for installing the panel locally.
  * Added configuration validation and publishing capabilities with clear error handling.

* **Bug Fixes**
  * Improved score override handling and reporting, including previous scores and fit details.

* **Tests**
  * Added coverage for configuration validation, publishing, and score override workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->