### PR TITLE
feat(capture): one-click outcome capture endpoint (INV-001 Rung 2)

### DIFF
--- a/src/jobfetcher/core/capture_token.py
+++ b/src/jobfetcher/core/capture_token.py
@@ -1,0 +1,122 @@
+"""HMAC-signed capture token (INV-001 Rung 2) — PURE: no I/O, no secret reading. The signing
+key is passed in as `bytes`; the *caller* (the handler/ingest layer) owns fetching it from
+Secrets Manager. Mirrors the v0.10.0 presigned-report pattern: a short-lived, tamper-evident
+token scoped to exactly `{posting_id, status}` so a "Mark applied" link in an email can drive
+ONE outcome write against a public endpoint without an unforgeable click being possible.
+
+Wire format: `base64url(payload) + "." + base64url(hmac_sha256(payload, key))`, where `payload`
+is compact, key-sorted JSON `{"pid": …, "st": …, "exp": <unix seconds>}`. JSON encodes the
+fields, so a `posting_id` carrying `:` (or any character) round-trips losslessly — no ad-hoc
+delimiter to escape. `exp` bounds the blast radius in time; the token is single-status and
+posting-scoped, so even a leaked one can only re-assert one specific outcome for one posting.
+
+`verify` is constant-time on the signature (`hmac.compare_digest`) and raises a typed
+`CaptureTokenError` for EVERY rejection — bad/missing signature, expired, malformed/tampered,
+or a status outside `APPLICATION_STATUSES` — with a GENERIC message (never leaking which check
+failed to a probing client); a coarse `reason` code is attached for server-side logs only.
+"""
+from __future__ import annotations
+
+import base64
+import hmac
+import json
+from dataclasses import dataclass
+from hashlib import sha256
+
+from .models import APPLICATION_STATUSES
+
+
+class CaptureTokenError(Exception):
+    """A capture token could not be trusted — bad/missing signature, expired, malformed, or an
+    out-of-vocabulary status. The public message is deliberately GENERIC (it never says which
+    check failed, so a probing client learns nothing); `reason` is a short code for server-side
+    logs ONLY, never surfaced to the caller."""
+
+    def __init__(self, reason: str = "invalid") -> None:
+        super().__init__("invalid or expired capture token")
+        self.reason = reason
+
+
+@dataclass(frozen=True)
+class CaptureClaim:
+    """The trusted contents of a verified token — exactly what the write path needs."""
+
+    posting_id: str
+    status: str
+
+
+def _b64url_encode(raw: bytes) -> str:
+    """URL-safe base64 WITHOUT padding (so the token is one clean query-param value)."""
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+
+def _b64url_decode(text: str) -> bytes:
+    """Inverse of `_b64url_encode` — re-add the stripped `=` padding before decoding."""
+    return base64.urlsafe_b64decode(text + ("=" * (-len(text) % 4)))
+
+
+def _sig(payload: bytes, key: bytes) -> bytes:
+    return hmac.new(key, payload, sha256).digest()
+
+
+def sign(*, posting_id: str, status: str, expires_at: int, key: bytes) -> str:
+    """Sign a `{posting_id, status, exp}` claim into `b64url(payload).b64url(hmac)`.
+
+    `expires_at` is unix seconds (the caller adds the TTL to `now`). `key` is the raw HMAC
+    secret bytes. Pure — deterministic for a given `(payload, key)`. Raises `CaptureTokenError`
+    on an empty key (a misconfiguration must not mint an unsigned-effectively token)."""
+    if not key:
+        raise CaptureTokenError("no-key")
+    payload = json.dumps(
+        {"pid": posting_id, "st": status, "exp": int(expires_at)},
+        separators=(",", ":"),
+        sort_keys=True,
+        ensure_ascii=True,
+    ).encode("utf-8")
+    return f"{_b64url_encode(payload)}.{_b64url_encode(_sig(payload, key))}"
+
+
+def verify(token: str, *, key: bytes, now: int) -> CaptureClaim:
+    """Return the `CaptureClaim` iff `token` is a well-formed, correctly-signed, unexpired token
+    whose status is in `APPLICATION_STATUSES`. Otherwise raise `CaptureTokenError` (generic
+    message, coarse `reason` for logs). The signature is checked in CONSTANT TIME
+    (`hmac.compare_digest`) BEFORE the payload is trusted, so a tampered payload fails at the
+    signature step; `now` is unix seconds (the caller passes the current time)."""
+    if not isinstance(token, str) or token.count(".") != 1:
+        raise CaptureTokenError("malformed")
+    payload_b64, sig_b64 = token.split(".")
+    try:
+        payload = _b64url_decode(payload_b64)
+        provided_sig = _b64url_decode(sig_b64)
+    except (ValueError, TypeError):
+        raise CaptureTokenError("malformed") from None
+
+    # Constant-time signature check FIRST — a tampered payload changes the digest and is
+    # rejected here, before its contents are ever parsed or trusted.
+    if not hmac.compare_digest(provided_sig, _sig(payload, key)):
+        raise CaptureTokenError("signature")
+
+    try:
+        claim = json.loads(payload)
+    except ValueError:
+        raise CaptureTokenError("malformed") from None
+    if not isinstance(claim, dict):
+        raise CaptureTokenError("malformed")
+
+    exp = claim.get("exp")
+    pid = claim.get("pid")
+    st = claim.get("st")
+    # bool is a subclass of int — exclude it so `exp=True` isn't read as `1`.
+    if not isinstance(exp, int) or isinstance(exp, bool):
+        raise CaptureTokenError("malformed")
+    if not isinstance(pid, str) or not pid:
+        raise CaptureTokenError("malformed")
+    if not isinstance(st, str):
+        raise CaptureTokenError("malformed")
+    if exp < now:
+        raise CaptureTokenError("expired")
+    # Defense in depth: `sign` is only ever called with a valid status, but a validly-signed
+    # token carrying an out-of-vocabulary status is still refused (never reaches the DB CHECK).
+    if st not in APPLICATION_STATUSES:
+        raise CaptureTokenError("status")
+    return CaptureClaim(posting_id=pid, status=st)

--- a/src/jobfetcher/core/capture_token.py
+++ b/src/jobfetcher/core/capture_token.py
@@ -82,6 +82,10 @@ def verify(token: str, *, key: bytes, now: int) -> CaptureClaim:
     message, coarse `reason` for logs). The signature is checked in CONSTANT TIME
     (`hmac.compare_digest`) BEFORE the payload is trusted, so a tampered payload fails at the
     signature step; `now` is unix seconds (the caller passes the current time)."""
+    # Symmetry with `sign`: an empty key is a misconfiguration, never a basis for trust. Both
+    # callers already guard `if not key`; this refuses it here too so `verify` is safe alone.
+    if not key:
+        raise CaptureTokenError("no-key")
     if not isinstance(token, str) or token.count(".") != 1:
         raise CaptureTokenError("malformed")
     payload_b64, sig_b64 = token.split(".")

--- a/src/jobfetcher/core/ingest.py
+++ b/src/jobfetcher/core/ingest.py
@@ -26,6 +26,8 @@ from .report import render_full_list
 from .scorer import ScorerError, subscores_payload
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from ..adapters.s3_audit import S3AuditStore
     from ..adapters.s3_raw import RawStore
     from ..adapters.s3_reports import ReportStore
@@ -34,6 +36,10 @@ if TYPE_CHECKING:
     from .ports import FilterStrategy, Notifier, Repository, SourceAdapter
     from .scorer import Scorer
     from .search_spec import SearchSpec
+
+    # The injected capture-link sink (INV-001): `(posting_id, status) -> url | None`, built by
+    # the handler where the base URL + signing key live. Threaded to the digest + full-list report.
+    CaptureLink = Callable[[str, str], "str | None"]
 
 # The single-user profile key (v0): one row in `profile`, the multi-user seam (db/tables.py).
 DEFAULT_USER_ID = "default"
@@ -845,6 +851,7 @@ def notify(
     run_date: date | None = None,
     max_age_days: int | None = None,
     report_store: "ReportStore | None" = None,
+    capture_link: "CaptureLink | None" = None,
 ) -> dict[str, int]:
     """Step-6 notification: load the profile (its **runtime** threshold) → read the scored
     shortlist (surfaced + below count) → render the daily digest → send it.
@@ -870,6 +877,11 @@ def notify(
     `report_store` is supplied, the whole build→upload→presign is best-effort inside a guard —
     any failure is logged and the digest STILL sends, degraded to today's plain text (no link).
     The email send itself stays loud, unchanged.
+
+    **The capture links are the same kind of enhancement (INV-001):** `capture_link` (built by
+    the handler where the base URL + signing key live) is threaded into both the digest and the
+    full-list report so each surfaced job carries a signed "Mark applied" link. `None` (capture
+    unconfigured) renders no capture link — never a reason the run fails.
 
     Returns `{surfaced, below_threshold, sent}` (`sent` is 1 — a send failure raises before
     we get here)."""
@@ -902,6 +914,7 @@ def notify(
                 threshold=threshold,
                 run_date=the_date,
                 generated_at=datetime.now(timezone.utc),
+                capture_link=capture_link,
             )
             report_key = f"reports/{the_date.isoformat()}/jobs-{run_id}.html"
             report_store.put_report(html=report_html, key=report_key)
@@ -919,7 +932,7 @@ def notify(
 
     subject, html_body, text_body = render_digest(
         items, below, threshold=threshold, date=the_date, since=since,
-        full_list_url=full_list_url,
+        full_list_url=full_list_url, capture_link=capture_link,
     )
     # A send failure propagates (NotifierError) — the v0 surface is the email; a failed send is
     # a failed run, not a swallowed warning (mirrors the loud DB-failure stance in score_gold).

--- a/src/jobfetcher/core/notifier.py
+++ b/src/jobfetcher/core/notifier.py
@@ -30,9 +30,15 @@ from typing import TYPE_CHECKING
 from urllib.parse import urlsplit
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from datetime import datetime
 
     from .ports import ShortlistItem
+
+    # A pure sink injected by the handler/ingest layer (where the base URL + signing key live):
+    # `capture_link(posting_id, status) -> url | None` (INV-001). `None`, or a `None` return,
+    # renders NO capture link — so the digest degrades gracefully when capture isn't configured.
+    CaptureLink = Callable[[str, str], "str | None"]
 
 # Only these URL schemes may become a clickable link. `apply_url` is untrusted JSearch input;
 # `html.escape` stops attribute-breakout but NOT a hostile scheme (`javascript:`/`data:`/
@@ -50,6 +56,7 @@ _BADGE_COLORS = {
 _BADGE_DEFAULT = "#5f6368"
 _APPLY_BG = "#1a73e8"  # the Apply button — a solid, obvious call to action
 _GRAD_GREEN = "#137333"  # the graduation badge — green text, email-client-safe (no images)
+_MARK_GREEN = "#137333"  # the "Mark as applied" capture action — green, next to Apply
 
 # The still-open section shows at most this many compact one-liners; the rest is a count
 # pointing at the export (ADR-0024) — the email stays scannable, the data stays reachable.
@@ -209,6 +216,7 @@ def render_digest(
     date: "date",
     since: "datetime | None" = None,
     full_list_url: str | None = None,
+    capture_link: "CaptureLink | None" = None,
 ) -> tuple[str, str, str]:
     """Render `(subject, html_body, text_body)` for the daily digest.
 
@@ -222,6 +230,11 @@ def render_digest(
     and the still-open "…and N more" overflow — so the compressed tail is reachable from the
     email. It is scheme-allowlisted via `_safe_apply_url`; a hostile scheme (or `None`) degrades
     gracefully to today's plain text (no link), never emitting an unsafe href.
+
+    `capture_link` (INV-001) is an injected `(posting_id, status) -> url | None` callable that
+    mints an HMAC-signed "Mark as applied" link. Each NEW card gets ONE prominent `applied`
+    action next to Apply (HTML + plaintext); the still-open one-liners stay uncluttered. `None`,
+    or a `None` return, renders no capture link — capture degrades off exactly like the report.
 
     Digest truthfulness: the items are split into **"New since last digest"** (full cards,
     first; a graduation gets the green `↑ old→new` badge) and **"still open"** (a count + the
@@ -290,7 +303,9 @@ def render_digest(
             f"JobFetcher digest — {day} — {n} new match{'es' if n != 1 else ''}", ""
         ]
     for card in new_cards:
-        text_lines.extend(_card_text_lines(card, threshold=threshold))
+        text_lines.extend(
+            _card_text_lines(card, threshold=threshold, capture_link=capture_link)
+        )
     if open_cards:
         text_lines.extend(_still_open_text_lines(open_cards, safe_full_url))
     if footer:
@@ -319,7 +334,10 @@ def render_digest(
                 '<h3 style="color:#202124;font-size:15px;margin:16px 0 8px;">'
                 "New since last digest</h3>"
             )
-        new_html += "".join(_card_html(card, threshold=threshold) for card in new_cards)
+        new_html += "".join(
+            _card_html(card, threshold=threshold, capture_link=capture_link)
+            for card in new_cards
+        )
     open_html = _still_open_html(open_cards, safe_full_url) if open_cards else ""
     if not footer:
         footer_html = ""
@@ -336,9 +354,12 @@ def render_digest(
     return subject, html_body, text_body
 
 
-def _card_text_lines(card: DigestCard, *, threshold: int) -> list[str]:
+def _card_text_lines(
+    card: DigestCard, *, threshold: int, capture_link: "CaptureLink | None" = None
+) -> list[str]:
     """One card's plaintext block: head (+ the `↑ old→new` graduation marker) · why · gap ·
-    apply · the dup footnote (`seen n× — scores lo–hi` + the collapsed member ids)."""
+    apply · (optional) the "mark applied" capture link · the dup footnote (`seen n× — scores
+    lo–hi` + the collapsed member ids)."""
     item = card.item
     loc = _location(item)
     head = f"[{item.score}] {_display_title(item)} — {(item.company or 'Unknown company').strip()}"
@@ -351,6 +372,9 @@ def _card_text_lines(card: DigestCard, *, threshold: int) -> list[str]:
     if gap:
         lines.append(f"    gap: {gap}")
     lines.append(f"    apply: {_safe_apply_url(item.apply_url) or '(no link)'}")
+    mark_url = capture_link(item.posting_id, "applied") if capture_link is not None else None
+    if mark_url:
+        lines.append(f"    mark applied: {mark_url}")
     if card.seen_count > 1:
         lines.append(
             f"    seen {card.seen_count}× — scores {card.score_lo}–{card.score_hi} "
@@ -383,9 +407,12 @@ def _still_open_text_lines(
     return lines
 
 
-def _card_html(card: DigestCard, *, threshold: int) -> str:
+def _card_html(
+    card: DigestCard, *, threshold: int, capture_link: "CaptureLink | None" = None
+) -> str:
     """One group = one bordered card: score badge (+ green `↑ old→new` graduation badge) ·
-    title · fit · Company·Location · why · gap · the `seen n×` dup footnote · Apply."""
+    title · fit · Company·Location · why · gap · the `seen n×` dup footnote · Apply (+ the
+    green "✓ Mark as applied" capture action when a `capture_link` is supplied)."""
     item = card.item
     title = escape(_display_title(item))
     company = escape((item.company or "Unknown company").strip())
@@ -433,6 +460,18 @@ def _card_html(card: DigestCard, *, threshold: int) -> str:
             "No apply link available</div>"
         )
 
+    # INV-001: the "Mark as applied" capture action — one HMAC-signed link next to Apply. The
+    # URL is our own (operator-configured base + signed token), escaped for the href; a `None`
+    # link (capture unconfigured) renders nothing.
+    mark_html = ""
+    mark_url = capture_link(item.posting_id, "applied") if capture_link is not None else None
+    if mark_url:
+        mark_html = (
+            f'<a href="{escape(mark_url, quote=True)}" '
+            f'style="display:inline-block;margin-left:12px;color:{_MARK_GREEN};'
+            'text-decoration:none;font-weight:bold;font-size:14px;">&#10003; Mark as applied</a>'
+        )
+
     fit_label = (
         f'<span style="color:#5f6368;font-size:12px;margin-left:8px;">{fit}</span>' if fit else ""
     )
@@ -449,7 +488,7 @@ def _card_html(card: DigestCard, *, threshold: int) -> str:
         f'<div style="color:#3c4043;font-size:14px;margin:8px 0 0;">&#10003; {why}</div>'
         f"{gap_html}"
         f"{seen_html}"
-        f"<div>{apply_html}</div>"
+        f"<div>{apply_html}{mark_html}</div>"
         "</td></tr></table>"
     )
 

--- a/src/jobfetcher/core/report.py
+++ b/src/jobfetcher/core/report.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from html import escape
 from typing import TYPE_CHECKING, Any
 
+from .models import APPLICATION_STATUSES
 from .notifier import (
     _APPLY_BG,
     _badge_color,
@@ -26,9 +27,14 @@ from .notifier import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from datetime import date, datetime
 
     from .ports import ShortlistItem
+
+    # Injected `(posting_id, status) -> url | None` (INV-001): mints an HMAC-signed capture link
+    # per outcome. `None` (capture unconfigured) omits the Mark column entirely — graceful.
+    CaptureLink = Callable[[str, str], "str | None"]
 
 
 def _join(values: list[Any]) -> str:
@@ -46,10 +52,27 @@ def _fmt_date(value: "datetime | date | None") -> str:
     return d.isoformat()
 
 
-def _row_html(item: "ShortlistItem", *, threshold: int) -> str:
+def _capture_cell(item: "ShortlistItem", capture_link: "CaptureLink") -> str:
+    """The "Mark" cell: one signed capture link per application status (INV-001) — the full
+    `APPLICATION_STATUSES` set, since a full page (unlike the email) can carry the whole outcome
+    vocabulary. A status whose link comes back `None` is skipped; an empty cell shows a dash. The
+    URL is our own signed link, escaped for the href; the status label is escaped too."""
+    links = [
+        f'<a href="{escape(url, quote=True)}" target="_blank" rel="noopener noreferrer">'
+        f"{escape(status)}</a>"
+        for status in APPLICATION_STATUSES
+        if (url := capture_link(item.posting_id, status))
+    ]
+    return " &middot; ".join(links) if links else '<span class="muted">&mdash;</span>'
+
+
+def _row_html(
+    item: "ShortlistItem", *, threshold: int, capture_link: "CaptureLink | None" = None
+) -> str:
     """One `<tr>` for the jobs table. `data-below` drives the below-threshold filter; the score
     cell carries `data-sort` so the numeric sort is by value, not lexical text. Every user/LLM
-    field is escaped; the apply link is scheme-allowlisted."""
+    field is escaped; the apply link is scheme-allowlisted. When `capture_link` is supplied, a
+    trailing "Mark" cell carries the per-status capture links; otherwise no cell is emitted."""
     score = item.score
     below = "1" if score < threshold else "0"
     override = "" if item.score_override is None else str(item.score_override)
@@ -70,6 +93,11 @@ def _row_html(item: "ShortlistItem", *, threshold: int) -> str:
         if safe_url
         else '<span class="muted">no link</span>'
     )
+    mark_cell = (
+        f'<td class="mark">{_capture_cell(item, capture_link)}</td>'
+        if capture_link is not None
+        else ""
+    )
     return (
         f'<tr data-below="{below}">'
         f'<td class="num" data-sort="{score}">'
@@ -85,6 +113,7 @@ def _row_html(item: "ShortlistItem", *, threshold: int) -> str:
         f"<td>{apply_cell}</td>"
         f'<td class="date">{scored}</td>'
         f'<td class="date">{fetched}</td>'
+        f"{mark_cell}"
         "</tr>"
     )
 
@@ -95,6 +124,7 @@ def render_full_list(
     threshold: int,
     run_date: "date",
     generated_at: "datetime | None" = None,
+    capture_link: "CaptureLink | None" = None,
 ) -> str:
     """Render the full-list HTML page over ALL scored `items` (surfaced + below-threshold, score
     DESC). Returns a complete, self-contained `<!doctype html>` document (inline CSS + JS, no
@@ -102,16 +132,25 @@ def render_full_list(
 
     `threshold` classifies each row (a below-threshold row is tagged for the "show below" filter);
     `run_date`/`generated_at` label the header. `render_full_list([])` returns a valid
-    "no scored jobs yet" page — never a crash or a blank body (the digest's zero-scored path)."""
+    "no scored jobs yet" page — never a crash or a blank body (the digest's zero-scored path).
+
+    `capture_link` (INV-001) is the injected `(posting_id, status) -> url | None` callable. When
+    supplied, each row gains a trailing "Mark" column with a signed capture link per application
+    status (the full page can carry the whole vocabulary); `None` omits the column entirely —
+    graceful degrade, identical to the digest, when capture isn't configured."""
     day = escape(run_date.isoformat())
     gen = escape(generated_at.strftime("%Y-%m-%d %H:%M UTC")) if generated_at is not None else ""
     total = len(items)
     surfaced = sum(1 for i in items if i.score >= threshold)
+    # INV-001: the Mark column exists only when capture is configured (a callable was injected).
+    mark_th = "<th>Mark</th>" if capture_link is not None else ""
 
     if not items:
         body = '<p class="empty">No scored jobs yet.</p>'
     else:
-        rows = "".join(_row_html(i, threshold=threshold) for i in items)
+        rows = "".join(
+            _row_html(i, threshold=threshold, capture_link=capture_link) for i in items
+        )
         body = f"""<div class="controls">
   <input id="q" type="search" placeholder="Filter by title, company, location…" oninput="filterRows()" />
   <label><input id="below" type="checkbox" checked onchange="filterRows()" /> show below-threshold</label>
@@ -132,6 +171,7 @@ def render_full_list(
   <th>Apply</th>
   <th onclick="sortBy(10,false)">Scored</th>
   <th onclick="sortBy(11,false)">Fetched</th>
+  {mark_th}
 </tr></thead>
 <tbody>{rows}</tbody>
 </table>
@@ -164,6 +204,7 @@ def render_full_list(
   td.title {{ font-weight:bold; }}
   td.why, td.gaps {{ max-width:280px; }}
   td.gaps {{ color:#a8641b; }}
+  td.mark {{ white-space:nowrap; font-size:12px; }}
   .badge {{ display:inline-block; color:#fff; font-weight:bold; padding:2px 8px; border-radius:12px; }}
   .muted {{ color:#9aa0a6; font-style:italic; }}
   a {{ color:{_APPLY_BG}; font-weight:bold; text-decoration:none; }}

--- a/src/jobfetcher/handlers/capture.py
+++ b/src/jobfetcher/handlers/capture.py
@@ -70,19 +70,33 @@ def resolve_capture_secret_name(env: dict[str, str]) -> str:
 
 
 # --------------------------------------------------------------------------- key resolution (I/O)
+# Warm-container cache for the Secrets-Manager-fetched signing key, keyed by secret id. The public
+# Function URL resolves the key on every non-blank-token request, so caching bounds Secrets Manager
+# reads (cost + throttling) under token spam to ONE per warm container. The env-var path (tests/dev)
+# is intentionally NOT cached — each call reflects the current env. The key is Terraform-owned and
+# unrotated; a rotation is picked up when the container recycles.
+_SECRET_KEY_CACHE: dict[str, bytes] = {}
+
+
 def _resolve_signing_key(env: dict[str, str]) -> bytes:
     """The HMAC signing key as bytes: `$CAPTURE_KEY` (tests/dev) wins, else Secrets Manager
-    (`$CAPTURE_KEY_SECRET_NAME`). Accepts a raw secret string or a JSON blob `{"key": "..."}` /
-    `{"api_key": "..."}` — mirrors `llm_openai._resolve_api_key`. The key is NEVER logged."""
+    (`$CAPTURE_KEY_SECRET_NAME`, cached per warm container). Accepts a raw secret string or a JSON
+    blob `{"key": "..."}` / `{"api_key": "..."}` — mirrors `llm_openai._resolve_api_key`. Never logged."""
     raw = (env.get(_CAPTURE_KEY_ENV) or "").strip()
     if raw:
         return raw.encode("utf-8")
+
+    secret_name = resolve_capture_secret_name(env)
+    cached = _SECRET_KEY_CACHE.get(secret_name)
+    if cached is not None:
+        return cached
+
     import boto3  # lazy: the env-var path (tests) needs no AWS SDK
 
     region = (env.get(_REGION_ENV) or "").strip() or _DEFAULT_REGION
     blob = (
         boto3.client("secretsmanager", region_name=region)
-        .get_secret_value(SecretId=resolve_capture_secret_name(env))
+        .get_secret_value(SecretId=secret_name)
         .get("SecretString")
         or ""
     ).strip()
@@ -91,7 +105,10 @@ def _resolve_signing_key(env: dict[str, str]) -> bytes:
         value = str(data.get("key") or data.get("api_key") or "").strip() or blob
     except (json.JSONDecodeError, AttributeError, TypeError):
         value = blob  # not JSON → the whole secret string is the key
-    return value.encode("utf-8")
+    key = value.encode("utf-8")
+    if key:  # never cache an empty/misconfigured key — let a corrected secret be picked up
+        _SECRET_KEY_CACHE[secret_name] = key
+    return key
 
 
 def build_capture_link(env: dict[str, str]) -> Callable[[str, str], str | None] | None:

--- a/src/jobfetcher/handlers/capture.py
+++ b/src/jobfetcher/handlers/capture.py
@@ -186,7 +186,7 @@ def _ok_html(status: str) -> dict[str, Any]:
 
 
 # --------------------------------------------------------------------------- handler
-def handler(event: dict[str, Any] | None = None, context: Any = None) -> dict[str, Any]:  # noqa: ARG001
+def handler(event: dict[str, Any] | None = None, context: Any = None) -> dict[str, Any]:
     """The capture Function URL entry point. Verify the token, then record the outcome.
 
     - missing/blank token → 400 (nothing written)
@@ -199,26 +199,30 @@ def handler(event: dict[str, Any] | None = None, context: Any = None) -> dict[st
     Never echoes the token or any secret; a rejected token logs only that it was rejected."""
     configure_log_level(os.environ)
     env = dict(os.environ)
+    # Correlation ID (house standard: "correlation IDs on every pipeline run", like pipeline.py's
+    # run_id): the Lambda request id labels every log line so interleaved lines from concurrent
+    # requests on this public endpoint stay traceable through verify → write → response.
+    rlog = logging.LoggerAdapter(log, {"request_id": getattr(context, "aws_request_id", "unknown")})
 
     token = _read_token(event)
     if not token:
-        log.info("capture: missing/blank token — 400")
+        rlog.info("capture: missing/blank token — 400")
         return _html(400, _MSG_INVALID)
 
     try:
         key = _resolve_signing_key(env)
     except Exception:  # noqa: BLE001 — a key-read failure is a server misconfig, not the client's
-        log.exception("capture: signing key unavailable — 500")
+        rlog.exception("capture: signing key unavailable — 500")
         return _html(500, _MSG_ERROR)
     if not key:
-        log.error("capture: empty signing key — 500")
+        rlog.error("capture: empty signing key — 500")
         return _html(500, _MSG_ERROR)
 
     try:
         claim = verify(token, key=key, now=int(time.time()))
     except CaptureTokenError as exc:
         # Never log the token — only that (and coarsely why) it was rejected.
-        log.info("capture: rejected token (reason=%s) — 400", exc.reason)
+        rlog.info("capture: rejected token (reason=%s) — 400", exc.reason)
         return _html(400, _MSG_INVALID)
 
     try:
@@ -230,13 +234,13 @@ def handler(event: dict[str, Any] | None = None, context: Any = None) -> dict[st
     except RepositoryError as exc:
         # Unknown posting (rolled back → zero rows) or a backend error — a 4xx either way; the
         # posting_id/status are safe to log (they are not secrets), the token is not logged.
-        log.warning("capture: not recorded (status=%s) — 404: %s", claim.status, exc)
+        rlog.warning("capture: not recorded (status=%s) — 404: %s", claim.status, exc)
         return _html(404, _MSG_NOT_FOUND)
     except Exception:  # noqa: BLE001 — any other failure is a server error, surfaced as 500
-        log.exception("capture: unexpected failure — 500")
+        rlog.exception("capture: unexpected failure — 500")
         return _html(500, _MSG_ERROR)
 
-    log.info(
+    rlog.info(
         "capture: recorded status=%s posting=%s — 200", claim.status, claim.posting_id
     )
     return _ok_html(claim.status)

--- a/src/jobfetcher/handlers/capture.py
+++ b/src/jobfetcher/handlers/capture.py
@@ -1,0 +1,225 @@
+"""The capture Lambda (INV-001 Rung 2) — a public AWS Lambda **Function URL** the digest/report
+"Mark applied / interview / …" links hit. It records ONE application outcome via the existing
+write path (`Repository.track_application_event`), closing the dark-feedback-loop: one click from
+the inbox → a row in the append-only `application_event` log (migration 0005), where before the
+only capture path was the CLI (`scripts/track.py`) and the outcome log stayed empty.
+
+**Auth = the token, not the network.** The Function URL is `authorization_type = "NONE"` (public);
+every request MUST carry a short-lived HMAC-signed token (`core/capture_token.py`) scoped to
+exactly `{posting_id, status}` with a TTL. A stray/forged/expired click can never write:
+`verify` runs BEFORE any DB touch, so a bad token returns 400 with ZERO rows written. The signing
+key lives in Secrets Manager (env-var fallback for tests), mirroring the pipeline's secret reads.
+
+Reuses, never reinvents: `resolve_db_url` + `configure_log_level` from the pipeline handler (the
+same reuse `scripts/track.py` makes) and `wait_for_db_resume` for the Aurora scale-to-0 cold
+resume. The capture Lambda ships in the SAME zip as the pipeline — a different handler entry point
+(`jobfetcher.handlers.capture.handler`), 256 MB / ~30 s (it does one verify + one small write).
+
+**Never echo the token or any secret** — no token value, no key, ever reaches a log line.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+import urllib.parse
+from html import escape
+from typing import Any, Callable
+
+from ..adapters.repository_postgres import PostgresRepository
+from ..core.capture_token import CaptureTokenError, sign, verify
+from ..core.ports import RepositoryError
+from ..db.engine import wait_for_db_resume
+from .pipeline import configure_log_level, resolve_db_url
+
+log = logging.getLogger(__name__)
+
+# Env the capture path reads. `CAPTURE_KEY` is the test/dev fallback (a raw key); in deployment
+# the key comes from Secrets Manager under `$CAPTURE_KEY_SECRET_NAME`. `CAPTURE_BASE_URL` is the
+# Function URL the pipeline stamps into every capture link (empty ⇒ links degrade off).
+_CAPTURE_KEY_ENV = "CAPTURE_KEY"
+_CAPTURE_KEY_SECRET_NAME_ENV = "CAPTURE_KEY_SECRET_NAME"
+_CAPTURE_BASE_URL_ENV = "CAPTURE_BASE_URL"
+_REGION_ENV = "AWS_REGION"  # Lambda sets this automatically at runtime
+_DEFAULT_CAPTURE_SECRET_NAME = "jobfetcher/capture-token"
+_DEFAULT_REGION = "us-east-1"
+
+# Capture-link lifetime. A "Mark applied" link lives inside an email the user may only act on
+# DAYS after it arrives (they apply, then remember to mark it), so a short TTL would break the
+# real workflow. 30 days is a sane upper bound: the token is single-status AND posting-scoped, so
+# the blast radius of a leaked/expired-but-replayed link is one specific outcome for one posting.
+CAPTURE_TOKEN_TTL_S = 30 * 24 * 3600
+
+_HTML_HEADERS = {"content-type": "text/html; charset=utf-8"}
+_MSG_INVALID = "This link is invalid or has expired."
+_MSG_NOT_FOUND = "This job could not be found — nothing was recorded."
+_MSG_ERROR = "Something went wrong. Please try again later."
+
+
+# --------------------------------------------------------------------------- pure resolvers
+def resolve_capture_base_url(env: dict[str, str]) -> str:
+    """`$CAPTURE_BASE_URL` (the deployed Function URL) or `""` when unset — an empty base URL
+    means capture links are not configured, so the digest/report render NONE (graceful). Pure."""
+    return (env.get(_CAPTURE_BASE_URL_ENV) or "").strip()
+
+
+def resolve_capture_secret_name(env: dict[str, str]) -> str:
+    """`$CAPTURE_KEY_SECRET_NAME` or the documented default Secrets Manager id. Pure."""
+    return (env.get(_CAPTURE_KEY_SECRET_NAME_ENV) or "").strip() or _DEFAULT_CAPTURE_SECRET_NAME
+
+
+# --------------------------------------------------------------------------- key resolution (I/O)
+def _resolve_signing_key(env: dict[str, str]) -> bytes:
+    """The HMAC signing key as bytes: `$CAPTURE_KEY` (tests/dev) wins, else Secrets Manager
+    (`$CAPTURE_KEY_SECRET_NAME`). Accepts a raw secret string or a JSON blob `{"key": "..."}` /
+    `{"api_key": "..."}` — mirrors `llm_openai._resolve_api_key`. The key is NEVER logged."""
+    raw = (env.get(_CAPTURE_KEY_ENV) or "").strip()
+    if raw:
+        return raw.encode("utf-8")
+    import boto3  # lazy: the env-var path (tests) needs no AWS SDK
+
+    region = (env.get(_REGION_ENV) or "").strip() or _DEFAULT_REGION
+    blob = (
+        boto3.client("secretsmanager", region_name=region)
+        .get_secret_value(SecretId=resolve_capture_secret_name(env))
+        .get("SecretString")
+        or ""
+    ).strip()
+    try:
+        data = json.loads(blob)
+        value = str(data.get("key") or data.get("api_key") or "").strip() or blob
+    except (json.JSONDecodeError, AttributeError, TypeError):
+        value = blob  # not JSON → the whole secret string is the key
+    return value.encode("utf-8")
+
+
+def build_capture_link(env: dict[str, str]) -> Callable[[str, str], str | None] | None:
+    """Build the `capture_link(posting_id, status) -> url | None` callable the notifier/report
+    inject, or `None` when capture is not configured (no base URL, or no resolvable key). The key
+    is resolved ONCE here (one Secrets Manager read per run), then reused to sign every link.
+
+    Fully guarded (an enhancement, NEVER a run-fatal path — the v0.10.0 report-guard stance): a
+    missing base URL or an unreadable key logs a warning and returns `None`, so the digest simply
+    renders without capture links; per-link signing failures also degrade to `None`."""
+    base_url = resolve_capture_base_url(env)
+    if not base_url:
+        return None
+    try:
+        key = _resolve_signing_key(env)
+    except Exception as exc:  # noqa: BLE001 — capture links must never fail the run
+        log.warning("capture links disabled — signing key unavailable: %s", exc)
+        return None
+    if not key:
+        log.warning("capture links disabled — empty signing key")
+        return None
+    prefix = base_url.rstrip("/")
+
+    def _link(posting_id: str, status: str) -> str | None:
+        try:
+            token = sign(
+                posting_id=posting_id,
+                status=status,
+                expires_at=int(time.time()) + CAPTURE_TOKEN_TTL_S,
+                key=key,
+            )
+            return f"{prefix}?t={urllib.parse.quote(token, safe='')}"
+        except Exception:  # noqa: BLE001 — a per-link failure just omits that one link
+            return None
+
+    return _link
+
+
+# --------------------------------------------------------------------------- request parsing
+def _read_token(event: Any) -> str:
+    """Pull the token out of the Function URL request (payload v2.0). The happy path is
+    `event["queryStringParameters"]["t"]` (already URL-decoded); fall back to parsing
+    `rawQueryString`. Defensive about missing/blank/non-dict shapes → `""` (the handler 400s)."""
+    if not isinstance(event, dict):
+        return ""
+    qs = event.get("queryStringParameters")
+    if isinstance(qs, dict):
+        t = qs.get("t")
+        if isinstance(t, str) and t.strip():
+            return t.strip()
+    raw = event.get("rawQueryString")
+    if isinstance(raw, str) and raw:
+        values = urllib.parse.parse_qs(raw).get("t")
+        if values and isinstance(values[0], str) and values[0].strip():
+            return values[0].strip()
+    return ""
+
+
+def _html(status_code: int, message: str) -> dict[str, Any]:
+    """A tiny self-contained HTML response (the click lands in a browser tab)."""
+    body = (
+        "<!doctype html><html lang=\"en\"><head><meta charset=\"utf-8\">"
+        "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">"
+        "<title>JobFetcher</title></head>"
+        "<body style=\"font-family:Arial,Helvetica,sans-serif;background:#f4f5f7;"
+        "color:#202124;text-align:center;padding:48px 16px;\">"
+        f"<p style=\"font-size:18px;\">{escape(message)}</p>"
+        "</body></html>"
+    )
+    return {"statusCode": status_code, "headers": dict(_HTML_HEADERS), "body": body}
+
+
+def _ok_html(status: str) -> dict[str, Any]:
+    return _html(200, f"✅ Recorded: {status}. You can close this tab.")
+
+
+# --------------------------------------------------------------------------- handler
+def handler(event: dict[str, Any] | None = None, context: Any = None) -> dict[str, Any]:  # noqa: ARG001
+    """The capture Function URL entry point. Verify the token, then record the outcome.
+
+    - missing/blank token → 400 (nothing written)
+    - forged / tampered / expired token, or a bad status → 400 (nothing written — `verify` runs
+      before any DB touch)
+    - a valid token whose posting is unknown → 404 (`track_application_event` rolls back → zero
+      rows) — a real backend error also surfaces here as a 4xx, never a silent success
+    - a valid token → exactly ONE `track_application_event` write → 200 HTML
+
+    Never echoes the token or any secret; a rejected token logs only that it was rejected."""
+    configure_log_level(os.environ)
+    env = dict(os.environ)
+
+    token = _read_token(event)
+    if not token:
+        log.info("capture: missing/blank token — 400")
+        return _html(400, _MSG_INVALID)
+
+    try:
+        key = _resolve_signing_key(env)
+    except Exception:  # noqa: BLE001 — a key-read failure is a server misconfig, not the client's
+        log.exception("capture: signing key unavailable — 500")
+        return _html(500, _MSG_ERROR)
+    if not key:
+        log.error("capture: empty signing key — 500")
+        return _html(500, _MSG_ERROR)
+
+    try:
+        claim = verify(token, key=key, now=int(time.time()))
+    except CaptureTokenError as exc:
+        # Never log the token — only that (and coarsely why) it was rejected.
+        log.info("capture: rejected token (reason=%s) — 400", exc.reason)
+        return _html(400, _MSG_INVALID)
+
+    try:
+        repo = PostgresRepository(resolve_db_url(env))
+        # Aurora scale-to-0 (ERR-009): a click landing on an idle cluster waits out the resume
+        # rather than dying on the first DB touch.
+        wait_for_db_resume(repo.engine)
+        repo.track_application_event(posting_id=claim.posting_id, status=claim.status)
+    except RepositoryError as exc:
+        # Unknown posting (rolled back → zero rows) or a backend error — a 4xx either way; the
+        # posting_id/status are safe to log (they are not secrets), the token is not logged.
+        log.warning("capture: not recorded (status=%s) — 404: %s", claim.status, exc)
+        return _html(404, _MSG_NOT_FOUND)
+    except Exception:  # noqa: BLE001 — any other failure is a server error, surfaced as 500
+        log.exception("capture: unexpected failure — 500")
+        return _html(500, _MSG_ERROR)
+
+    log.info(
+        "capture: recorded status=%s posting=%s — 200", claim.status, claim.posting_id
+    )
+    return _ok_html(claim.status)

--- a/src/jobfetcher/handlers/pipeline.py
+++ b/src/jobfetcher/handlers/pipeline.py
@@ -454,6 +454,14 @@ def handler(event: dict[str, Any] | None = None, context: Any = None) -> dict[st
             notify_counts = {"surfaced": 0, "below_threshold": 0, "sent": 0}
         else:
             rlog.info("stage=notify start recipient=%s", recipient)
+            # INV-001: the "Mark applied" capture links. `build_capture_link` reads the base URL
+            # (env) + signing key (Secrets Manager) ONCE and returns a signer closure, or None
+            # when capture isn't configured — fully guarded, never a run-fatal path. Imported
+            # lazily so the pipeline↔capture reuse (capture reads resolve_db_url from here) has no
+            # module-load import cycle.
+            from .capture import build_capture_link
+
+            capture_link = build_capture_link(env)
             notify_counts = notify(
                 run_id=run_id,
                 repo=repo,
@@ -467,6 +475,8 @@ def handler(event: dict[str, Any] | None = None, context: Any = None) -> dict[st
                 # B-1: the full-list report + presigned link (best-effort inside notify —
                 # a report failure degrades the digest to plain text, never fails the run).
                 report_store=report_store,
+                # INV-001: the capture-link signer (None → no "Mark applied" links; graceful).
+                capture_link=capture_link,
             )
             # Mark sent ONLY after a successful send (notify raises on a failed send, so we never
             # get here on failure — the guard is not written, the next run re-sends).

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -45,3 +45,24 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:febef068317f8e49bd438ccdf2f54345fc3bc4b80a2699d9ab3c449d7e521d8e",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.9.0"
+  constraints = ">= 3.5.0"
+  hashes = [
+    "h1:q/uaUTBdKgAmZESrwsoeDQff9uUA/cI/N5ZKNgVwa9c=",
+    "zh:161ad0bd9a75768c82f53fb6e7172a9d8be2d4889b012645a34795031aaf1bf1",
+    "zh:19dc9a5b17729725ccfc4f45b0500af0ee5bc6b6b160c7adb8f2bf617d2c80ea",
+    "zh:269eda8fe42daa7974d5a34d166c3ba9defe80cde86c01e4dadcfdf2e1f05e5f",
+    "zh:373f7c65566f8f2cc7f45d698654feb9d988996957e1266a69ca00c52d6d16d0",
+    "zh:5599d16804c41c83009ec621b6d6b6f74e102f5827678a4750f8809055546b61",
+    "zh:583be0440469a22bff70dcfa56593b01566860b29607437264adb51060cf46fc",
+    "zh:5f211d8ec3f2e1f414870d9584bfe26e6995560ef81c748f8447a48164767398",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b547fd16216761ef86efc3ed516ac5ac0c5c42b7c7eb24a08cef2d93f69ed5e",
+    "zh:7e7c0679daf2a382151d05068c8c3f0dae6b7b7dccf818827b73dd08638df2ef",
+    "zh:8089dec888a8038b9b4fb23b3df7e1057293dbc5b60b42cc47ff690d69d4b61b",
+    "zh:c51f15a031edfd6f23ce8ced3446ca7f8d8d647e2499890d7d5d10d5016d7257",
+    "zh:c94784f005708890dc6895afd53636ec00ec1e430b15d41e5aebfb1d4b39bd04",
+  ]
+}

--- a/terraform/capture.tf
+++ b/terraform/capture.tf
@@ -97,6 +97,12 @@ resource "aws_lambda_function" "capture" {
   timeout     = 30  # one token verify + one small Data-API write (+ Aurora cold-resume headroom)
   memory_size = 256 # tiny work; no LLM, no S3, no concurrency
 
+  # Cap the public endpoint's concurrency: real use is a human clicking a few links/day, so 5 is
+  # generous. Reserving it also (a) bounds the cost/blast-radius of token-spam against the public
+  # URL, and (b) walls the capture Lambda off from the account concurrency pool so it can never
+  # starve the pipeline Lambda. The DB is already protected (verify fails before any DB touch).
+  reserved_concurrent_executions = 5
+
   environment {
     variables = {
       ENV = var.env

--- a/terraform/capture.tf
+++ b/terraform/capture.tf
@@ -1,0 +1,128 @@
+# capture.tf — the public capture endpoint (INV-001 Rung 2).
+#
+# WHAT: a second Lambda (SAME deployment zip, a different handler entry point) exposed via a
+#       public Lambda Function URL, plus the HMAC signing key it verifies against. The digest/
+#       report "Mark applied / interview / …" links hit this URL → the handler verifies the
+#       short-lived signed token → records ONE outcome via the existing write path.
+# WHY:  the dark-feedback-loop (INV-001): outcome capture was CLI-only, so the log stayed empty.
+#       One click from the inbox now lands a row. Auth is the TOKEN, not the network — the URL is
+#       `authorization_type = "NONE"` (public) but every request must carry a valid HMAC token
+#       scoped to {posting_id, status} with a TTL (the v0.10.0 presigned-report pattern).
+# SO-WHAT: closes the loop that blocks M7 scoring calibration, at the cost of exactly one small
+#       public surface whose blast radius is bounded (single-status, posting-scoped, expiring).
+#
+# The signing key is generated + owned by Terraform (a SELF-owned secret, not a third-party
+# credential — unlike deepseek/jsearch which are CLI-created data sources). State lives in the
+# private S3 backend, so `random_password` in state is acceptable here.
+
+resource "random_password" "capture_key" {
+  length  = 48
+  special = false # alphanumeric — a clean HMAC secret with no shell/URL-escaping surprises
+}
+
+resource "aws_secretsmanager_secret" "capture_key" {
+  name        = var.capture_key_secret_name
+  description = "HMAC signing key for JobFetcher capture-link tokens (INV-001). Terraform-owned."
+}
+
+resource "aws_secretsmanager_secret_version" "capture_key" {
+  secret_id     = aws_secretsmanager_secret.capture_key.id
+  secret_string = random_password.capture_key.result
+}
+
+# ── Least-privilege execution role for the capture Lambda ────────────────────
+# Narrower than the pipeline role: it needs the Data API + the two secrets the DB engine and the
+# token verify require + Logs. NO S3, NO SES, NO deepseek/jsearch, NO bedrock.
+resource "aws_iam_role" "capture" {
+  name               = "jobfetcher-${var.env}-capture"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume.json # reuse the pipeline's assume doc
+}
+
+data "aws_iam_policy_document" "capture_policy" {
+  # Read ONLY the two secrets this endpoint needs: the token signing key + the Aurora master
+  # password secret (the Data API authenticates the cluster call with it).
+  statement {
+    sid     = "ReadCaptureSecrets"
+    actions = ["secretsmanager:GetSecretValue"]
+    resources = [
+      aws_secretsmanager_secret.capture_key.arn,
+      aws_rds_cluster.main.master_user_secret[0].secret_arn,
+    ]
+  }
+
+  # RDS Data API: exactly the statements track_application_event's transaction issues.
+  statement {
+    sid = "DataApi"
+    actions = [
+      "rds-data:ExecuteStatement",
+      "rds-data:BatchExecuteStatement",
+      "rds-data:BeginTransaction",
+      "rds-data:CommitTransaction",
+      "rds-data:RollbackTransaction",
+    ]
+    resources = [aws_rds_cluster.main.arn]
+  }
+
+  # CloudWatch Logs for the capture function's own log group.
+  statement {
+    sid = "Logs"
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    ]
+    resources = ["arn:aws:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/jobfetcher-${var.env}-capture*"]
+  }
+}
+
+resource "aws_iam_role_policy" "capture" {
+  name   = "jobfetcher-${var.env}-capture"
+  role   = aws_iam_role.capture.id
+  policy = data.aws_iam_policy_document.capture_policy.json
+}
+
+# ── The capture Lambda — the SAME zip as the pipeline, a different handler ─────
+resource "aws_lambda_function" "capture" {
+  function_name = "jobfetcher-${var.env}-capture"
+  role          = aws_iam_role.capture.arn
+  runtime       = var.lambda_runtime
+
+  # INV-001 entry point, in the same package built by scripts/build_lambda.py (build/lambda/).
+  handler = "jobfetcher.handlers.capture.handler"
+
+  # Reuse the pipeline's build zip — one artifact, two entry points (P1: no second package).
+  filename         = data.archive_file.lambda.output_path
+  source_code_hash = data.archive_file.lambda.output_base64sha256
+
+  timeout     = 30  # one token verify + one small Data-API write (+ Aurora cold-resume headroom)
+  memory_size = 256 # tiny work; no LLM, no S3, no concurrency
+
+  environment {
+    variables = {
+      ENV = var.env
+      # Data API connection (no JOBFETCHER_DB_URL → resolve_db_url builds the Aurora URL).
+      DB_CLUSTER_ARN = aws_rds_cluster.main.arn
+      DB_SECRET_ARN  = aws_rds_cluster.main.master_user_secret[0].secret_arn
+      DB_NAME        = var.db_name
+      # The signing-key secret the handler verifies tokens against.
+      CAPTURE_KEY_SECRET_NAME = aws_secretsmanager_secret.capture_key.name
+      LOG_LEVEL               = "INFO"
+    }
+  }
+}
+
+# ── The public Function URL — auth is the TOKEN, not IAM ──────────────────────
+resource "aws_lambda_function_url" "capture" {
+  function_name      = aws_lambda_function.capture.function_name
+  authorization_type = "NONE" # public: every request carries a signed, expiring HMAC token
+}
+
+# A public Function URL still needs an explicit resource policy allowing the (unauthenticated)
+# InvokeFunctionUrl action — without it the URL returns 403.
+resource "aws_lambda_permission" "capture_url" {
+  statement_id           = "AllowPublicFunctionUrlInvoke"
+  action                 = "lambda:InvokeFunctionUrl"
+  function_name          = aws_lambda_function.capture.function_name
+  principal              = "*"
+  function_url_auth_type = "NONE"
+}

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -23,8 +23,9 @@ resource "aws_iam_role" "lambda" {
 }
 
 data "aws_iam_policy_document" "lambda_policy" {
-  # ── Secrets: read ONLY the three secrets this pipeline uses ────────────────
-  # deepseek + jsearch (app keys) and the Aurora-managed master-password secret.
+  # ── Secrets: read ONLY the secrets this pipeline uses ──────────────────────
+  # deepseek + jsearch (app keys), the Aurora-managed master-password secret, and the capture
+  # signing key (INV-001 — the pipeline SIGNS the "Mark applied" links with it).
   statement {
     sid     = "ReadAppSecrets"
     actions = ["secretsmanager:GetSecretValue"]
@@ -32,6 +33,7 @@ data "aws_iam_policy_document" "lambda_policy" {
       data.aws_secretsmanager_secret.deepseek.arn,
       data.aws_secretsmanager_secret.jsearch.arn,
       aws_rds_cluster.main.master_user_secret[0].secret_arn,
+      aws_secretsmanager_secret.capture_key.arn,
     ]
   }
 

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -64,6 +64,11 @@ resource "aws_lambda_function" "pipeline" {
       # Telemetry verbosity for the `jobfetcher` package logger (ERR-009 rider) — the code
       # defaults to INFO when unset; this entry just makes the knob IaC-visible.
       LOG_LEVEL = "INFO"
+      # INV-001: the capture endpoint the "Mark applied" links point at + the signing-key secret
+      # name. The pipeline signs the links (build_capture_link); the capture Lambda verifies them.
+      # An empty CAPTURE_BASE_URL would just disable the links (graceful) — here it is always set.
+      CAPTURE_BASE_URL        = aws_lambda_function_url.capture.function_url
+      CAPTURE_KEY_SECRET_NAME = aws_secretsmanager_secret.capture_key.name
     }
   }
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -49,3 +49,8 @@ output "alarms_topic_arn" {
   description = "SNS alarms topic ARN — used to verify the email subscription is confirmed (deploy runbook §4)."
   value       = aws_sns_topic.alarms.arn
 }
+
+output "capture_function_url" {
+  description = "Public capture endpoint (INV-001) the digest/report 'Mark applied' links hit. Auth is the signed HMAC token, not IAM."
+  value       = aws_lambda_function_url.capture.function_url
+}

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -37,6 +37,11 @@ terraform {
       source  = "hashicorp/archive"
       version = ">= 2.4"
     }
+    # random: generates the self-owned HMAC capture-token signing key (INV-001, capture.tf).
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.5"
+    }
   }
 }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -60,6 +60,14 @@ variable "jsearch_secret_name" {
   default     = "jobfetcher/jsearch"
 }
 
+# The capture-token HMAC signing key secret (INV-001). Unlike deepseek/jsearch this secret is
+# CREATED + owned by Terraform (capture.tf) — a self-owned key, not a third-party credential.
+variable "capture_key_secret_name" {
+  description = "Secrets Manager id for the Terraform-generated capture-token HMAC signing key."
+  type        = string
+  default     = "jobfetcher/capture-token"
+}
+
 # S3 object KEYS for the two config YAMLs (ADR-0022). The handler reads them from S3 at runtime
 # (env vars below become s3://<data-bucket>/<key>), so a settings change = edit the YAML +
 # `scripts/push_config.py` — no Lambda rebuild/redeploy.

--- a/tests/test_capture_handler.py
+++ b/tests/test_capture_handler.py
@@ -1,0 +1,154 @@
+"""Unit tests for the capture Lambda (INV-001 Rung 2) — no DB, no AWS: the repository is faked
+and the signing key comes from `$CAPTURE_KEY`. Mirrors the dossier's VG-a/VG-b at the handler
+boundary: a valid token writes EXACTLY ONE outcome + returns 200 HTML; a forged/expired/missing
+token writes NOTHING + returns 4xx (the repo is never even constructed); an unknown posting
+(RepositoryError) surfaces as 4xx. Also covers the `build_capture_link` factory the pipeline uses
+to mint links, and the graceful-degrade (no base URL / no key → None)."""
+from __future__ import annotations
+
+import time
+import urllib.parse
+
+import pytest
+
+import jobfetcher.handlers.capture as capture
+from jobfetcher.core.capture_token import sign, verify
+from jobfetcher.core.ports import RepositoryError
+
+_KEY_STR = "unit-test-signing-key"
+_KEY = _KEY_STR.encode()
+
+
+def _token(pid: str = "jsearch:123", status: str = "applied", ttl: int = 3600) -> str:
+    return sign(posting_id=pid, status=status, expires_at=int(time.time()) + ttl, key=_KEY)
+
+
+@pytest.fixture
+def wired(monkeypatch):
+    """Fake the repo + no-op the Aurora resume wait; supply the key + a DB URL via env. `state`
+    exposes every constructed repo (to prove zero/one write) and lets a test arm a raise."""
+    state: dict = {"repos": [], "raise_exc": None}
+
+    class _FakeRepo:
+        def __init__(self, url):
+            self.url = url
+            self.engine = object()
+            self.calls: list[tuple[str, str]] = []
+            state["repos"].append(self)
+
+        def track_application_event(self, *, posting_id, status, note=None):
+            self.calls.append((posting_id, status))
+            if state["raise_exc"] is not None:
+                raise state["raise_exc"]
+
+    monkeypatch.setattr(capture, "PostgresRepository", _FakeRepo)
+    monkeypatch.setattr(capture, "wait_for_db_resume", lambda engine, **kw: None)
+    monkeypatch.setenv("CAPTURE_KEY", _KEY_STR)
+    monkeypatch.setenv("JOBFETCHER_DB_URL", "postgresql://u:p@localhost/db")
+    return state
+
+
+# --------------------------------------------------------------------------- VG-a positive
+def test_valid_token_records_exactly_once_and_200(wired):
+    token = _token()
+    resp = capture.handler({"queryStringParameters": {"t": token}})
+    assert resp["statusCode"] == 200
+    assert resp["headers"]["content-type"] == "text/html; charset=utf-8"
+    assert "Recorded" in resp["body"] and "applied" in resp["body"]
+    # exactly ONE write, for the right posting + status
+    assert len(wired["repos"]) == 1
+    assert wired["repos"][0].calls == [("jsearch:123", "applied")]
+    # the response never echoes the token
+    assert token not in resp["body"]
+
+
+def test_raw_querystring_fallback_records(wired):
+    # some Function URL payload shapes carry only rawQueryString — the handler still finds `t`
+    resp = capture.handler({"rawQueryString": f"t={_token()}"})
+    assert resp["statusCode"] == 200
+    assert wired["repos"][0].calls == [("jsearch:123", "applied")]
+
+
+def test_later_status_records_a_distinct_outcome(wired):
+    # VG-b: a second, later status for the same posting is its own recorded outcome (the
+    # append-only log preserves history — the repo never overwrites)
+    resp = capture.handler({"queryStringParameters": {"t": _token(status="interview")}})
+    assert resp["statusCode"] == 200
+    assert wired["repos"][0].calls == [("jsearch:123", "interview")]
+
+
+# --------------------------------------------------------------------------- VG-a negatives
+def test_forged_token_writes_nothing_and_4xx(wired):
+    token = _token()
+    payload_b64, sig_b64 = token.split(".")
+    forged = f"{payload_b64}.{('A' if sig_b64[0] != 'A' else 'B') + sig_b64[1:]}"
+    resp = capture.handler({"queryStringParameters": {"t": forged}})
+    assert resp["statusCode"] == 400
+    assert wired["repos"] == []  # repo never constructed → ZERO writes on a bad token
+
+
+def test_expired_token_writes_nothing_and_4xx(wired):
+    resp = capture.handler({"queryStringParameters": {"t": _token(ttl=-10)}})
+    assert resp["statusCode"] == 400
+    assert wired["repos"] == []
+
+
+@pytest.mark.parametrize(
+    "event",
+    [
+        None,
+        {},
+        {"queryStringParameters": None},
+        {"queryStringParameters": {}},
+        {"queryStringParameters": {"t": "   "}},
+        {"rawQueryString": ""},
+    ],
+)
+def test_missing_or_blank_token_4xx_no_write(wired, event):
+    resp = capture.handler(event)
+    assert resp["statusCode"] == 400
+    assert wired["repos"] == []
+
+
+def test_unknown_posting_returns_4xx(wired):
+    # the repo rejects an unknown posting with RepositoryError (zero rows — its own contract);
+    # the handler surfaces that as a 4xx, never a 200
+    wired["raise_exc"] = RepositoryError("no posting 'jsearch:nope' — nothing written")
+    resp = capture.handler({"queryStringParameters": {"t": _token(pid="jsearch:nope")}})
+    assert resp["statusCode"] == 404
+    assert len(wired["repos"]) == 1  # attempted exactly once (no retry), then rolled back
+
+
+def test_empty_signing_key_is_server_error_no_write(wired, monkeypatch):
+    # a misconfigured (empty) key is a 500 — a server problem, not the client's — and never writes
+    monkeypatch.setattr(capture, "_resolve_signing_key", lambda env: b"")
+    resp = capture.handler({"queryStringParameters": {"t": _token()}})
+    assert resp["statusCode"] == 500
+    assert wired["repos"] == []
+
+
+# --------------------------------------------------------------------------- build_capture_link
+def test_resolve_capture_base_url():
+    assert capture.resolve_capture_base_url({}) == ""
+    assert capture.resolve_capture_base_url({"CAPTURE_BASE_URL": " https://c/ "}) == "https://c/"
+
+
+def test_build_capture_link_mints_verifiable_url():
+    env = {"CAPTURE_BASE_URL": "https://cap.example.com/c", "CAPTURE_KEY": _KEY_STR}
+    link = capture.build_capture_link(env)
+    assert link is not None
+    url = link("jsearch:9", "applied")
+    assert url.startswith("https://cap.example.com/c?t=")
+    token = urllib.parse.unquote(url.split("t=", 1)[1])
+    claim = verify(token, key=_KEY, now=int(time.time()))
+    assert claim.posting_id == "jsearch:9" and claim.status == "applied"
+
+
+def test_build_capture_link_none_without_base_url():
+    # graceful degrade: no base URL configured → no capture links at all
+    assert capture.build_capture_link({"CAPTURE_KEY": _KEY_STR}) is None
+
+
+def test_build_capture_link_none_without_key(monkeypatch):
+    monkeypatch.setattr(capture, "_resolve_signing_key", lambda env: b"")
+    assert capture.build_capture_link({"CAPTURE_BASE_URL": "https://c"}) is None

--- a/tests/test_capture_token.py
+++ b/tests/test_capture_token.py
@@ -113,3 +113,11 @@ def test_generic_message_does_not_leak_which_check_failed():
 def test_sign_rejects_empty_key():
     with pytest.raises(CaptureTokenError):
         sign(posting_id="p", status="applied", expires_at=_FUTURE, key=b"")
+
+
+def test_verify_rejects_empty_key():
+    # Symmetry with sign: an empty key is a misconfiguration, never a basis for trust — verify
+    # refuses it up front rather than HMAC-ing against an empty secret.
+    token = sign(posting_id="p", status="applied", expires_at=_FUTURE, key=_KEY)
+    with pytest.raises(CaptureTokenError):
+        verify(token, key=b"", now=_NOW)

--- a/tests/test_capture_token.py
+++ b/tests/test_capture_token.py
@@ -1,0 +1,115 @@
+"""Unit tests for the pure HMAC capture token (INV-001 Rung 2): sign→verify round-trip, and
+every rejection path — tampered payload/signature, expired, wrong key, and an out-of-vocabulary
+status — each raising the typed `CaptureTokenError` with a GENERIC message. No I/O: the key is a
+plain `bytes`, `now`/`exp` are plain ints."""
+from __future__ import annotations
+
+import base64
+import json
+
+import pytest
+
+from jobfetcher.core.capture_token import (
+    CaptureClaim,
+    CaptureTokenError,
+    sign,
+    verify,
+)
+
+_KEY = b"a-test-signing-key-0123456789"
+_NOW = 1_700_000_000
+_FUTURE = _NOW + 3600
+_PAST = _NOW - 1
+
+
+# --------------------------------------------------------------------------- round-trip
+def test_sign_verify_round_trip():
+    token = sign(posting_id="jsearch:abc123", status="applied", expires_at=_FUTURE, key=_KEY)
+    claim = verify(token, key=_KEY, now=_NOW)
+    assert claim == CaptureClaim(posting_id="jsearch:abc123", status="applied")
+
+
+def test_posting_id_with_special_chars_round_trips():
+    # a posting_id with ':' and '/' must survive — JSON encodes it, no delimiter to escape
+    pid = "jsearch:https://boards.example.com/a:b/c?d=1"
+    token = sign(posting_id=pid, status="interview", expires_at=_FUTURE, key=_KEY)
+    claim = verify(token, key=_KEY, now=_NOW)
+    assert claim.posting_id == pid and claim.status == "interview"
+
+
+def test_token_is_two_base64url_segments():
+    token = sign(posting_id="p", status="applied", expires_at=_FUTURE, key=_KEY)
+    assert token.count(".") == 1
+    # both halves are URL-safe base64 (no '+' or '/' or '=' padding)
+    for seg in token.split("."):
+        assert "+" not in seg and "/" not in seg and "=" not in seg
+
+
+# --------------------------------------------------------------------------- negatives
+def test_tampered_payload_is_rejected():
+    token = sign(posting_id="p", status="applied", expires_at=_FUTURE, key=_KEY)
+    payload_b64, sig_b64 = token.split(".")
+    # forge the payload to a different posting_id, keep the original signature
+    forged_payload = {"pid": "p-evil", "st": "offer", "exp": _FUTURE}
+    forged_b64 = (
+        base64.urlsafe_b64encode(json.dumps(forged_payload).encode()).rstrip(b"=").decode()
+    )
+    with pytest.raises(CaptureTokenError):
+        verify(f"{forged_b64}.{sig_b64}", key=_KEY, now=_NOW)
+
+
+def test_tampered_signature_is_rejected():
+    token = sign(posting_id="p", status="applied", expires_at=_FUTURE, key=_KEY)
+    payload_b64, sig_b64 = token.split(".")
+    bad_sig = ("A" if sig_b64[0] != "A" else "B") + sig_b64[1:]
+    with pytest.raises(CaptureTokenError):
+        verify(f"{payload_b64}.{bad_sig}", key=_KEY, now=_NOW)
+
+
+def test_wrong_key_is_rejected():
+    token = sign(posting_id="p", status="applied", expires_at=_FUTURE, key=_KEY)
+    with pytest.raises(CaptureTokenError):
+        verify(token, key=b"a-different-key", now=_NOW)
+
+
+def test_expired_token_is_rejected():
+    token = sign(posting_id="p", status="applied", expires_at=_PAST, key=_KEY)
+    with pytest.raises(CaptureTokenError) as exc:
+        verify(token, key=_KEY, now=_NOW)
+    assert exc.value.reason == "expired"
+    # the public message never says which check failed
+    assert "expired" in str(exc.value) or "invalid" in str(exc.value)
+    assert "signature" not in str(exc.value)
+
+
+def test_status_outside_vocabulary_is_rejected():
+    # a validly-SIGNED token (right key) carrying a bogus status is still refused by verify —
+    # it can never reach the DB CHECK
+    token = sign(posting_id="p", status="hired", expires_at=_FUTURE, key=_KEY)
+    with pytest.raises(CaptureTokenError) as exc:
+        verify(token, key=_KEY, now=_NOW)
+    assert exc.value.reason == "status"
+
+
+@pytest.mark.parametrize("bad", ["", "no-dot-here", "a.b.c", "!!!.@@@", "onlyonesegment."])
+def test_malformed_tokens_are_rejected(bad):
+    with pytest.raises(CaptureTokenError):
+        verify(bad, key=_KEY, now=_NOW)
+
+
+def test_generic_message_does_not_leak_which_check_failed():
+    # bad signature and expired both surface the SAME generic message (no oracle for a prober)
+    good = sign(posting_id="p", status="applied", expires_at=_FUTURE, key=_KEY)
+    payload_b64, sig_b64 = good.split(".")
+    bad_sig_token = f"{payload_b64}.{('A' if sig_b64[0] != 'A' else 'B') + sig_b64[1:]}"
+    expired_token = sign(posting_id="p", status="applied", expires_at=_PAST, key=_KEY)
+    with pytest.raises(CaptureTokenError) as e_sig:
+        verify(bad_sig_token, key=_KEY, now=_NOW)
+    with pytest.raises(CaptureTokenError) as e_exp:
+        verify(expired_token, key=_KEY, now=_NOW)
+    assert str(e_sig.value) == str(e_exp.value)  # identical public message
+
+
+def test_sign_rejects_empty_key():
+    with pytest.raises(CaptureTokenError):
+        sign(posting_id="p", status="applied", expires_at=_FUTURE, key=b"")

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -8,12 +8,15 @@ repo + fake notifier (counts; zero-matches still sends; send failure RAISES; sin
 threading). Each carries a negative."""
 from __future__ import annotations
 
+import re
+import time
 from datetime import date, datetime, timedelta, timezone
 from typing import Any
 
 import pytest
 
 from jobfetcher.adapters.ses_notifier import _SENDER_ENV, SesNotifier
+from jobfetcher.core.capture_token import sign, verify
 from jobfetcher.core.ingest import notify
 from jobfetcher.core.notifier import (
     collapse_duplicates,
@@ -21,6 +24,16 @@ from jobfetcher.core.notifier import (
     split_new_and_still_open,
 )
 from jobfetcher.core.ports import NotifierError, ShortlistItem
+
+_CAPTURE_KEY = b"digest-capture-key"
+
+
+def _capture_link(pid: str, status: str) -> str:
+    """A real signing capture_link for the render tests — the token must verify back."""
+    return (
+        "https://cap.example.com/c?t="
+        + sign(posting_id=pid, status=status, expires_at=int(time.time()) + 3600, key=_CAPTURE_KEY)
+    )
 
 # A canned "last digest went out" time for the truthfulness tests (since != None), plus a
 # judgment written AFTER it (fresh — can be news) and one BEFORE it (stale — a daily repeat).
@@ -66,6 +79,33 @@ def test_render_digest_matches_carry_core_fields():
     assert "+3 more scored below your threshold of 60" in html
     # html has a clickable apply link
     assert 'href="https://jobs.example.com/apply/123"' in html
+
+
+def test_render_digest_renders_capture_link_that_verifies_back():
+    # INV-001: each new card carries a "Mark as applied" capture link whose token verifies back
+    # to exactly {posting_id, 'applied'} — in BOTH the html and the plaintext.
+    _, html, text = render_digest(
+        [_item(90, "p1")], below_count=0, threshold=60, date=date(2026, 6, 27),
+        capture_link=_capture_link,
+    )
+    assert "Mark as applied" in html
+    assert "mark applied" in text.lower()
+    now = int(time.time())
+    for body in (html, text):
+        m = re.search(r"\?t=([A-Za-z0-9_\-.]+)", body)
+        assert m is not None
+        claim = verify(m.group(1), key=_CAPTURE_KEY, now=now)
+        assert claim.posting_id == "p1" and claim.status == "applied"
+
+
+def test_render_digest_no_capture_link_when_unconfigured():
+    # negative: with no capture_link injected, NO "Mark applied" affordance renders (graceful)
+    _, html, text = render_digest(
+        [_item(90, "p1")], below_count=0, threshold=60, date=date(2026, 6, 27)
+    )
+    assert "Mark as applied" not in html
+    assert "mark applied" not in text.lower()
+    assert "?t=" not in html and "?t=" not in text
 
 
 def test_render_digest_prominent_apply_button_and_card_fields():

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -4,13 +4,25 @@ asset, all user/LLM text escaped, the apply link scheme-allowlisted, and `render
 a valid "no jobs" page (never a crash/blank). Each carries a negative."""
 from __future__ import annotations
 
+import re
+import time
 from datetime import date, datetime, timezone
 from typing import Any
 
+from jobfetcher.core.capture_token import sign, verify
+from jobfetcher.core.models import APPLICATION_STATUSES
 from jobfetcher.core.ports import ShortlistItem
 from jobfetcher.core.report import render_full_list
 
 _GEN = datetime(2026, 7, 10, 6, 0, tzinfo=timezone.utc)
+_CAPTURE_KEY = b"report-capture-key"
+
+
+def _capture_link(pid: str, status: str) -> str:
+    return (
+        "https://cap.example.com/c?t="
+        + sign(posting_id=pid, status=status, expires_at=int(time.time()) + 3600, key=_CAPTURE_KEY)
+    )
 
 
 def _item(score: int, pid: str = "p", **over: Any) -> ShortlistItem:
@@ -50,6 +62,31 @@ def test_render_full_list_is_self_contained_valid_page():
     assert "Acme Corp" in html and "Beta Ltd" in html
     assert "90" in html and "72" in html
     assert "2026-07-10" in html  # the run-date header
+
+
+def test_render_full_list_renders_capture_links_that_verify():
+    # INV-001: with a capture_link, each row gains a "Mark" column with a signed link per
+    # application status; every token verifies back to (posting_id, that status).
+    html = render_full_list(
+        [_item(90, "a")], threshold=60, run_date=date(2026, 7, 10), capture_link=_capture_link
+    )
+    assert "<th>Mark</th>" in html
+    assert ">applied</a>" in html  # the 'applied' hint (Rung 1) is present, prominently
+    now = int(time.time())
+    tokens = re.findall(r"\?t=([A-Za-z0-9_\-.]+)", html)
+    claims = [verify(t, key=_CAPTURE_KEY, now=now) for t in tokens]
+    # the full outcome vocabulary is wired, all for posting 'a'
+    assert {c.status for c in claims} == set(APPLICATION_STATUSES)
+    assert all(c.posting_id == "a" for c in claims)
+    # one of them is exactly the {a, applied} link the digest also emits
+    assert ("a", "applied") in {(c.posting_id, c.status) for c in claims}
+
+
+def test_render_full_list_no_mark_column_without_capture():
+    # negative: no capture_link → no Mark column, no capture tokens (graceful, unchanged page)
+    html = render_full_list([_item(90, "a")], threshold=60, run_date=date(2026, 7, 10))
+    assert "<th>Mark</th>" not in html
+    assert "?t=" not in html
 
 
 def test_render_full_list_includes_below_threshold_rows_tagged():


### PR DESCRIPTION
## What

Closes the **dark feedback loop** ([INV-001](docs/investigations/INV-001-dark-feedback-loop/README.md)): outcome capture was CLI-only (`scripts/track.py`), so `application_event` had **0 rows** and scoring had zero ground truth. This adds a **one-click "Mark applied" path from the email/report** → a row in the append-only outcome log.

**Rung 2** (human-approved at Checkpoint A): a public **Lambda Function URL** that the digest/report links hit → verifies a short-lived **HMAC-signed token** scoped to `{posting_id, status}` → records ONE outcome via the existing `Repository.track_application_event`. **Auth is the token, not the network** — a forged/expired token returns 400 with **zero rows written** (`verify` runs before any DB touch).

## How
- `core/capture_token.py` — pure HMAC sign/verify; constant-time compare; 30-day TTL; rejects bad-sig/expired/malformed/out-of-vocab-status/empty-key.
- `handlers/capture.py` — the Function URL Lambda (same zip, `jobfetcher.handlers.capture.handler`); verifies before any DB touch; reuses `track_application_event`; returns HTML; never logs the token/key; caches the signing key per warm container.
- `core/notifier.py` / `core/report.py` / `core/ingest.py` — a `capture_link(posting_id, status) -> url | None` callable injected into the renderers (they stay pure); one "✓ Mark as applied" per new digest card + a Mark column in the full-list report; **degrades to no-link** when unconfigured.
- `terraform/capture.tf` (+ `iam.tf`/`lambda.tf`/`outputs.tf`/`providers.tf`/`variables.tf`) — the capture Lambda + public Function URL + Terraform-owned signing-key secret + least-privilege IAM (Data-API + its two secrets + Logs only) + `reserved_concurrent_executions = 5`.

## Squad + review
- **Investigator** dossier → verified live (0 outcomes, `score_override` 1/286), standards-audited.
- **Examiner** (fresh, adversarial, two-pass) → **CLEAN PASS, zero blocking findings**; traced the security core by hand + ran the gate independently.
- **Non-blocking findings adjudicated:** #2 (key caching + concurrency cap) and #3 (verify rejects empty key) **fixed in this PR**; #4/#5 accepted per ADR-0026; **#1 (GET-prefetch) surfaced for the human decision below**.

## ⚠️ One decision for review — GET-prefetch
The links are one-click **GET** URLs (the dossier's chosen design). An email link-scanner / preview bot that *pre-fetches* the URL could record a spurious `applied`. Ruled **non-blocking** (single-user Gmail, obscure URL, append-only + override-correctable, one-click was explicitly approved) — but it's the most material risk. Accept as-is (add a confirm-interstitial fast-follow only if spurious rows appear), **or** add the interstitial now?

## Gate
`pytest -m "not integration"` → **451 passed** · `ruff` clean · `terraform fmt` clean. No DB migration, no new runtime dependency. Live deploy is a separate checkpoint.

## Versioning
Per the new convention: **no per-unit tag** — this lands in CHANGELOG `[Unreleased]` and batches into the next `v0.12.x` patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added secure “Mark applied” and status-action links to email digests and full-list reports.
  * Added a capture endpoint that records application outcomes from signed links.
  * Capture links expire automatically and degrade gracefully when unavailable.
* **Security**
  * Added signed, tamper-resistant tokens with validation and generic error responses.
* **Tests**
  * Added coverage for token validation, capture handling, link rendering, expiration, and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->