### PR TITLE
feat(alarms): page on a returned statusCode:500 (INV-002)

### DIFF
--- a/docs/investigations/INV-002-silent-500-alarm/README.md
+++ b/docs/investigations/INV-002-silent-500-alarm/README.md
@@ -43,7 +43,7 @@ The handler deliberately converts stage failures into a returned `statusCode:500
 ## Validation gate
 | # | Behavioral (positive) | Negative case |
 |---|---|---|
-| VG-a | A **normal-mode** run that fails a stage → the log contains `PIPELINE_ALARM`; the metric filter matches that line (`aws logs test-metric-filter --filter-pattern '"PIPELINE_ALARM"'` → matches only the marker), so the alarm would fire. | A **smoke-mode** and a **reassess-mode** 500 → the log has `pipeline failed` but **NOT** `PIPELINE_ALARM` (no false-fire) — `test_returned_500_alarm_marker_only_on_unattended_run`. |
+| VG-a | A **normal-mode** run that fails a stage → the log contains `PIPELINE_ALARM`; the metric filter matches that line — runnable: `aws logs test-metric-filter --filter-pattern '"PIPELINE_ALARM"' --log-event-messages "PIPELINE_ALARM: unattended run returned statusCode=500" "pipeline failed: RuntimeError: boom" "pipeline done {...}"` → **only** the marker line matches — so the alarm would fire. | A **smoke-mode** and a **reassess-mode** 500 → the log has `pipeline failed` but **NOT** `PIPELINE_ALARM` (no false-fire) — `test_returned_500_alarm_marker_only_on_unattended_run`. |
 | VG-b | Post-deploy: `describe-alarms --alarm-names jobfetcher-<env>-pipeline-returned-500` exists + wired to the SNS topic; the filter is present on the log group. | On a healthy stack the alarm sits `OK`/`INSUFFICIENT_DATA` — it does not fire without a real returned-500. |
 
 ## Out of scope / rejected

--- a/docs/investigations/INV-002-silent-500-alarm/README.md
+++ b/docs/investigations/INV-002-silent-500-alarm/README.md
@@ -1,0 +1,74 @@
+---
+id: INV-002
+title: Silent 500 — a returned statusCode:500 pages nobody
+status: in-progress
+severity: non-crucial   # additive observability (2 alarms + a marker); touches live infra but low-risk, no scoring/schema/dep/PII
+logged: 2026-07-20
+updated: 2026-07-21
+source: B-3 "still-parked companion" (backlog) + the 2026-07-11 P2 scan; picked 2026-07-20 as the top *unblocked* bottleneck
+---
+
+# INV-002 · Silent 500 — a returned statusCode:500 pages nobody
+
+**Status:** `in-progress` · **Severity:** `non-crucial` · **Owner of the fix:** the agentic squad
+
+> The pipeline handler *catches* a stage failure and **returns** `statusCode:500` — which is a **successful** invocation to Lambda, so the AWS/Lambda Errors alarm never counts it and nobody is paged. An unattended daily run can die silently.
+
+## The problem
+The daily cron runs unattended (v0.9.0). When a stage fails, the handler returns `{statusCode:500}` rather than crashing — good for idempotent re-runs, but the two existing alarms miss it: the **dead-man** only fires if the run *didn't happen*, and the **Lambda Errors** alarm only counts crashes/timeouts (a *returned* 500 is a successful invocation). So a run that fails every stage and sends no digest raises **zero alerts** — exactly what happened on **2026-07-09** (a missed digest, no page).
+
+## Does it exist? — verification
+**Yes — confirmed in code + the ops config (re-runnable):**
+
+- **Evidence 1 — the handler returns 500, never raises.** [`handlers/pipeline.py:486-496`](../../../src/jobfetcher/handlers/pipeline.py): the outer `except` logs `rlog.exception("pipeline failed: %s", exc)` then **returns** `{"statusCode": 500, ...}`. A returned dict is a *successful* Lambda invocation → the `AWS/Lambda Errors` metric is **not** incremented.
+  Reproduce: read the except block, and `tests/test_db_resume.py::test_handler_wait_failure_is_still_a_loud_500` shows a forced failure → `out["statusCode"] == 500` (a return, not a raise).
+- **Evidence 2 — the alarm can't see it, and the gap is self-documented.** [`terraform/alarms.tf`](../../../terraform/alarms.tf) has exactly two alarms: `pipeline_dead_man` (`AWS/Events Invocations < 1`) and `pipeline_errors` (`AWS/Lambda Errors >= 1`). The Errors-alarm comment states the gap verbatim: *"the handler catches stage failures and RETURNS `statusCode: 500` — a SUCCESSFUL invocation to Lambda, invisible here."* [ADR-0029](../../adr/0029-ops-hardening.md) names it a "documented future refinement."
+- **Magnitude:** a *whole class* of failure (any returned-500 on the unattended path) is unmonitored; realized once already (2026-07-09, zero alerts). Low-frequency but high-consequence (silent daily-tool death).
+
+## Mechanism (root cause)
+The handler deliberately converts stage failures into a returned `statusCode:500` (retryable, idempotent) instead of an unhandled exception. Lambda's `Errors` metric only counts unhandled exceptions/timeouts, so the *returned* 500 is invisible to it. There is **no signal** an alarm can bind to — the only text on the failure path is the generic `pipeline failed` line, which is **also** emitted by attended-mode 500s (smoke's pre-migration/DB-unreachable gate, manual reassess), so it can't be matched naively.
+
+## Blast radius
+- **Changes:** `terraform/alarms.tf` (a managed log group + a log-metric-filter + an alarm) + a mode-gated marker line in `handlers/pipeline.py`.
+- **Must NOT change:** the two existing alarms, the SNS topic + its email subscription, or the handler's return contract (still returns 500; the marker is additive).
+- **Unaffected:** the whole pipeline (fetch → … → notify); the change is observability-only.
+
+## Fix plan (the handoff guideline)
+1. **A mode-gated marker** (`handlers/pipeline.py`, the outer `except`): after the existing `pipeline failed` line, emit `PIPELINE_ALARM` **only when** `mode not in ("smoke", "reassess")` — so only the *unattended* daily 500 is alarmable (`mode` is already resolved before the `try`). Reuse the existing `rlog`.
+2. **Terraform** (`terraform/alarms.tf`): manage `aws_cloudwatch_log_group.pipeline` (retention bonus; **import once** on the running stack — the group is Lambda-auto-created), a `aws_cloudwatch_log_metric_filter` on `pattern = "\"PIPELINE_ALARM\""` → metric `JobFetcher/Pipeline / PipelineReturned500`, and a `aws_cloudwatch_metric_alarm` (`Sum >= 1`, `notBreaching`) → **reuse** `aws_sns_topic.alarms.arn`. Mirror the existing `pipeline_errors` alarm shape.
+3. **Tests:** the marker fires on a normal-mode 500, not on smoke/reassess.
+
+**Rejected:** an infra-only filter on `"pipeline failed"` — false-fires on the *expected* pre-migration smoke 500 + manual reassess → alarm fatigue (the project's no-false-green ethos). The ~4-line mode-gated marker buys precision cheaply.
+
+## Validation gate
+| # | Behavioral (positive) | Negative case |
+|---|---|---|
+| VG-a | A **normal-mode** run that fails a stage → the log contains `PIPELINE_ALARM`; the metric filter matches that line (`aws logs test-metric-filter --filter-pattern '"PIPELINE_ALARM"'` → matches only the marker), so the alarm would fire. | A **smoke-mode** and a **reassess-mode** 500 → the log has `pipeline failed` but **NOT** `PIPELINE_ALARM` (no false-fire) — `test_returned_500_alarm_marker_only_on_unattended_run`. |
+| VG-b | Post-deploy: `describe-alarms --alarm-names jobfetcher-<env>-pipeline-returned-500` exists + wired to the SNS topic; the filter is present on the log group. | On a healthy stack the alarm sits `OK`/`INSUFFICIENT_DATA` — it does not fire without a real returned-500. |
+
+## Out of scope / rejected
+- **A "digest didn't send" (returned-200-but-empty) alarm** — a different gap (partial runs skip notify by design); not this unit.
+- **Managing the capture Lambda's log group** — only the pipeline is the alarm target here.
+- **A custom EMF/structured-logging overhaul** — the text-term filter is sufficient at this scale.
+
+## Connections (typed — the graph seam)
+- `caused-by` → `file:src/jobfetcher/handlers/pipeline.py` (returns 500 instead of raising)
+- `relates-to` → [ADR-0029](../../adr/0029-ops-hardening.md) (the two alarms + the documented gap this closes)
+- `touches` → `file:terraform/alarms.tf`
+- `touches` → `file:src/jobfetcher/handlers/pipeline.py`
+- `blocks` → "trustworthy unattended ops" (a silent daily failure)
+- `relates-to` → [B-3 companion](../../ledgers/backlog.md) (where this was first named)
+
+## Handoff
+- **Severity tier:** `non-crucial` (additive observability; touches live CloudWatch but low-risk, no scoring/schema/dep/PII). The one-time log-group **import** is a non-destructive state op; the deploy is the standing checkpoint.
+- **Ready-for-Surgeon checklist:** verified ✅ · root-caused ✅ · fix plan ✅ · validation gate (behavioral + negative) ✅ · out-of-scope ✅ · typed connections ✅.
+- **On fix:** the **Resolution** section below is filled at close → set `status: fixed`.
+
+## Resolution — as-built _(filled at close)_
+> ⏳ **Pending** — filled when the fix ships (deployed + alarm live).
+
+- **What shipped:** _(the as-built)_.
+- **Rung taken · divergence from the Fix plan:** _(any deviation + why)_.
+- **Key files + decisions:** _(where the code lives; the load-bearing choices)_.
+- **Links:** PR #… · CHANGELOG `[Unreleased]` · commit `<sha>`.
+- **Extending / editing later:** _(the seams; the gotchas)_.

--- a/docs/investigations/README.md
+++ b/docs/investigations/README.md
@@ -44,6 +44,7 @@ Every dossier's **Connections** section is a list of typed edges — a graph-in-
 | ID | Title | Status | Severity | One-liner | Backlog / ADR |
 |---|---|---|---|---|---|
 | [INV-001](INV-001-dark-feedback-loop/) | Dark feedback loop — the tool has no ground truth | `fixed` | crucial¹ | 0 outcomes logged (live-verified 2026-07-20) → **Rung 2 capture endpoint shipped + live-validated** (PR #34): one click from the email records an outcome | [B-3 companion](../ledgers/backlog.md) · M7 · [ADR-0035](../adr/0035-outcome-capture-endpoint.md) |
+| [INV-002](INV-002-silent-500-alarm/) | Silent 500 — a returned statusCode:500 pages nobody | `in-progress` | non-crucial | A returned 500 is a *successful* Lambda invocation → invisible to the Errors alarm (0 alerts on the 2026-07-09 missed digest) → mode-gated marker + log-metric-filter alarm | [B-3 companion](../ledgers/backlog.md) · [ADR-0029](../adr/0029-ops-hardening.md) |
 
 ¹ crucial for the recommended fix (a public capture endpoint — live infra + auth); a rung-1 interim is non-crucial.
 

--- a/src/jobfetcher/handlers/pipeline.py
+++ b/src/jobfetcher/handlers/pipeline.py
@@ -485,6 +485,14 @@ def handler(event: dict[str, Any] | None = None, context: Any = None) -> dict[st
 
     except Exception as exc:  # noqa: BLE001 — surface ANY stage failure as a retryable 500
         rlog.exception("pipeline failed: %s", exc)
+        # A RETURNED statusCode:500 is a *successful* invocation to Lambda, so the AWS/Lambda
+        # Errors alarm never counts it (ADR-0029 gap). This distinctive marker is what the
+        # CloudWatch metric-filter → SNS alarm keys off (terraform/alarms.tf). Only the UNATTENDED
+        # daily run emits it: smoke (the deploy gate — a pre-migration/DB-unreachable 500 is
+        # expected + you're present) and reassess (manual, attended) are excluded so the alarm
+        # never cries wolf. `mode` is resolved above, before the try, so it's always bound here.
+        if mode not in ("smoke", "reassess"):
+            rlog.error("PIPELINE_ALARM: unattended run returned statusCode=500")
         error_summary = {
             "statusCode": 500,
             "run_id": run_id,

--- a/terraform/alarms.tf
+++ b/terraform/alarms.tf
@@ -59,12 +59,13 @@ resource "aws_cloudwatch_metric_alarm" "pipeline_dead_man" {
 
 # ERRORS: the Lambda crashed or timed out (an unhandled exception / hard timeout increments
 # AWS/Lambda `Errors`). `notBreaching` on missing data because NO invocations is not a crash —
-# the dead-man above owns that case. Honest gap: the handler catches stage failures and RETURNS
-# `statusCode: 500` — a SUCCESSFUL invocation to Lambda, invisible here. Catching returned 500s
-# needs a custom metric (a documented future step, built when a real miss justifies it).
+# the dead-man above owns that case. This alarm covers crashes/timeouts ONLY; a handler that
+# CATCHES a stage failure and RETURNS `statusCode: 500` is a SUCCESSFUL invocation to Lambda,
+# invisible here — that gap is now closed by the log-metric-filter alarm below (was the
+# ADR-0029 "documented future step").
 resource "aws_cloudwatch_metric_alarm" "pipeline_errors" {
   alarm_name        = "jobfetcher-${var.env}-pipeline-errors"
-  alarm_description = "The pipeline Lambda crashed or timed out (>= 1 error in the last hour). Returned statusCode-500 summaries are NOT counted — only unhandled crashes/timeouts."
+  alarm_description = "The pipeline Lambda crashed or timed out (>= 1 error in the last hour). Returned statusCode-500 summaries are caught by the pipeline-returned-500 alarm, not here."
 
   namespace   = "AWS/Lambda"
   metric_name = "Errors"
@@ -78,6 +79,53 @@ resource "aws_cloudwatch_metric_alarm" "pipeline_errors" {
   comparison_operator = "GreaterThanOrEqualToThreshold"
   threshold           = 1
   treat_missing_data  = "notBreaching" # no invocations ≠ a crash; the dead-man covers silence
+
+  alarm_actions = [aws_sns_topic.alarms.arn]
+  ok_actions    = [aws_sns_topic.alarms.arn] # recovery notification
+}
+
+# RETURNED statusCode:500 — the gap the AWS/Lambda Errors alarm above can't see (a returned 500 is
+# a *successful* invocation). We manage the pipeline's log group so a metric filter has a
+# guaranteed target (Lambda auto-creates it otherwise; on an already-running stack import it once:
+# `terraform import aws_cloudwatch_log_group.pipeline /aws/lambda/jobfetcher-<env>-pipeline`).
+# retention_in_days also bounds today's unbounded log storage.
+resource "aws_cloudwatch_log_group" "pipeline" {
+  name              = "/aws/lambda/jobfetcher-${var.env}-pipeline"
+  retention_in_days = 30
+}
+
+# The handler emits `PIPELINE_ALARM` ONLY on an unattended daily-run 500 (smoke/reassess excluded,
+# so the alarm never cries wolf — see handlers/pipeline.py). This filter turns that log line into a
+# custom metric. Quoted text term (the logs are unstructured Lambda-default text, not JSON).
+resource "aws_cloudwatch_log_metric_filter" "pipeline_returned_500" {
+  name           = "jobfetcher-${var.env}-pipeline-returned-500"
+  log_group_name = aws_cloudwatch_log_group.pipeline.name
+  pattern        = "\"PIPELINE_ALARM\""
+
+  metric_transformation {
+    name          = "PipelineReturned500"
+    namespace     = "JobFetcher/Pipeline"
+    value         = "1"
+    default_value = "0" # emit 0 on non-matching evaluation windows → the alarm has data to read
+  }
+}
+
+# Page when the daily pipeline RETURNS a 500 (>= 1 marker in the window). Same SNS topic + email as
+# the other two alarms. notBreaching on missing data: no marker = healthy (the dead-man owns "the
+# run didn't happen at all").
+resource "aws_cloudwatch_metric_alarm" "pipeline_returned_500" {
+  alarm_name        = "jobfetcher-${var.env}-pipeline-returned-500"
+  alarm_description = "The unattended daily pipeline caught a stage failure and RETURNED statusCode:500 (invisible to the AWS/Lambda Errors alarm). Smoke/reassess 500s are excluded at the source."
+
+  namespace   = "JobFetcher/Pipeline"
+  metric_name = "PipelineReturned500"
+
+  statistic           = "Sum"
+  period              = 300
+  evaluation_periods  = 1
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  threshold           = 1
+  treat_missing_data  = "notBreaching" # no marker = no returned-500; the dead-man covers silence
 
   alarm_actions = [aws_sns_topic.alarms.arn]
   ok_actions    = [aws_sns_topic.alarms.arn] # recovery notification

--- a/tests/test_db_resume.py
+++ b/tests/test_db_resume.py
@@ -304,3 +304,35 @@ def test_handler_wait_failure_is_still_a_loud_500(monkeypatch, tmp_path, pkg_log
     assert out["statusCode"] == 500
     assert "DatabaseResumingException" in out["error"]
     assert "upsert_profile" not in calls  # nothing touched the DB after the failed wait
+
+
+# The silent-500 alarm marker (INV-002): a RETURNED statusCode:500 is invisible to the AWS/Lambda
+# Errors alarm, so the handler emits a distinctive `PIPELINE_ALARM` log line that a CloudWatch
+# metric-filter → SNS alarm keys off — but ONLY for the unattended daily run. Smoke (deploy gate,
+# where a pre-migration/DB-unreachable 500 is expected and you're present) and reassess (manual,
+# attended) must NOT emit it, or the alarm cries wolf. Every mode 500s here via the same failed
+# resume wait; only the mode differs.
+@pytest.mark.parametrize(
+    ("event", "marker_expected"),
+    [
+        ({}, True),  # unattended daily cron → page
+        ({"mode": ""}, True),  # normal pipeline, explicit empty mode → page
+        ({"mode": "reassess"}, False),  # manual/attended replay → no page
+        ({"mode": "smoke"}, False),  # deploy gate; a pre-migration 500 is expected → no page
+    ],
+)
+def test_returned_500_alarm_marker_only_on_unattended_run(
+    monkeypatch, tmp_path, pkg_logger_restored, caplog, event, marker_expected
+):
+    calls: list[str] = []
+
+    def _exhausted():
+        raise _resume_error()
+
+    pipe = _wire_handler(monkeypatch, tmp_path, calls, wait=_exhausted)
+    with caplog.at_level("ERROR", logger="jobfetcher.handlers.pipeline"):
+        out = pipe.handler(event, None)
+    assert out["statusCode"] == 500  # every mode still returns the loud 500
+    logged = "\n".join(r.getMessage() for r in caplog.records)
+    assert "pipeline failed" in logged  # the debug line is emitted regardless of mode
+    assert ("PIPELINE_ALARM" in logged) is marker_expected  # the alarm marker is mode-gated


### PR DESCRIPTION
## What
Closes the **silent-500 alarm gap** ([INV-002](docs/investigations/INV-002-silent-500-alarm/README.md), the ADR-0029 documented gap): the pipeline handler *returns* `statusCode:500` on a stage failure — a **successful** invocation to Lambda, so the `AWS/Lambda Errors` alarm never counts it and **nobody is paged**. The unattended daily cron can die silently (it did on 2026-07-09 — a missed digest, zero alerts).

## How
- **`handlers/pipeline.py`** — the outer `except` emits a distinctive **`PIPELINE_ALARM`** marker, **mode-gated to the unattended daily run only**: smoke (deploy gate — a pre-migration/DB-unreachable 500 is *expected*, and you're present) and reassess (manual) are excluded so the alarm never cries wolf. `pipeline failed` (debug) is unchanged.
- **`terraform/alarms.tf`** — a managed pipeline log group (retention 30d, also bounds today's unbounded log storage) + a log-metric-filter on `"PIPELINE_ALARM"` → `JobFetcher/Pipeline/PipelineReturned500` → an alarm (`Sum>=1`, `notBreaching`) **reusing the existing SNS topic**.
- **`tests/test_db_resume.py`** — the marker fires on a normal-mode 500, **not** on smoke/reassess (the false-fire guard).

## Review
- **Examiner (fresh, adversarial): CLEAN PASS — zero blocking findings.** Verified `mode` is always bound at the except, the false-fire guard holds, the `default_value=0`+`notBreaching` composition, and the full failure→email chain. Ran the gate independently.
- Rejected an infra-only `"pipeline failed"` filter (false-fires on the expected smoke 500 → alarm fatigue).

## ⚠️ Deploy note
The pipeline log group is Lambda-auto-created (unmanaged). On the running stack, `terraform apply` needs a **one-time import** first: `terraform import aws_cloudwatch_log_group.pipeline /aws/lambda/jobfetcher-dev-pipeline`. Documented in-code + the dossier. A fresh clone needs no import.

## Gate
`pytest -m "not integration"` → **455 passed** · `ruff` clean · `terraform validate`+`fmt` clean · filter pattern proven via `aws logs test-metric-filter` (matches only the marker). No migration, no new dependency.

## Versioning
No per-unit tag — lands in CHANGELOG `[Unreleased]`, batches into the next `v0.12.x`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added monitoring for pipeline failures that return HTTP 500 responses without triggering standard Lambda error alarms.
  - Alerts now notify through the existing alerting channel for unattended pipeline runs.
  - Smoke and manual reassessment runs are excluded from these alerts.

- **Documentation**
  - Added an investigation record and index entry describing the silent 500 failure mode, impact, and validation plan.

- **Tests**
  - Added coverage confirming alert behavior across unattended, smoke, and reassessment run modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->