### PR TITLE
fix(iac): stop Terraform reconciling Aurora's engine version (ERR-012 follow-up)

### DIFF
--- a/docs/runbooks/deploy.md
+++ b/docs/runbooks/deploy.md
@@ -92,3 +92,23 @@ review flags, and the migration cost only grows with the data.
 Once the data stops being replaceable this becomes a snapshot → encrypted-copy → restore
 migration instead, which is a different and much longer procedure.
 
+## 6 · Aurora MAJOR version upgrades (the `ignore_changes` caveat)
+
+`terraform/aurora.tf` carries `lifecycle { ignore_changes = [engine_version] }` on both the
+cluster and its instance ([ERR-012](../ledgers/errors.md)). That is what stops Terraform
+fighting AWS's `auto_minor_version_upgrade` — which had it attempting to **downgrade the live
+database on every apply**, blocking a deploy outright.
+
+The cost: **a major upgrade will not apply while it is there.** Minor versions are AWS's and
+need no action. For a major (e.g. 16 → 17):
+
+1. Read the Aurora PostgreSQL major-upgrade notes and take a manual snapshot first — this one
+   is not the throwaway-data path.
+2. Temporarily remove `ignore_changes = [engine_version]` from **both** `aws_rds_cluster.main`
+   and `aws_rds_cluster_instance.main`.
+3. Set the new major in `engine_version`, `terraform plan`, and **read it** — a major upgrade
+   is a real, disruptive operation, not an in-place attribute change.
+4. Apply, verify, then put `ignore_changes` back.
+
+Never leave it removed: without it the next AWS minor patch re-creates ERR-012.
+

--- a/terraform/aurora.tf
+++ b/terraform/aurora.tf
@@ -81,6 +81,24 @@ resource "aws_rds_cluster" "main" {
   skip_final_snapshot = true
   apply_immediately   = true
 
+  lifecycle {
+    # ERR-012. `auto_minor_version_upgrade` is true, so AWS owns the minor version and moves
+    # it without us (it took this cluster 16.6 -> 16.11 on its own). Terraform reads that as
+    # drift and tries to push it back: at best a pointless ModifyDBCluster, at worst a
+    # downgrade AWS refuses outright -- which is exactly what blocked the ERR-010 deploy.
+    # A major-only `engine_version` does NOT suppress the diff on this provider (verified
+    # 2026-09-01: it still plans `16.11 -> "16"`), so the reconciliation must be turned off.
+    #
+    # The literal above is still load-bearing: it governs cluster CREATION, so a fresh apply
+    # after the destroy cadence still lands on 16.x (Data API + scale-to-0 + pgvector). This
+    # only stops Terraform re-asserting the version on an EXISTING cluster.
+    #
+    # A MAJOR upgrade (16 -> 17) will NOT apply while this is here. That is deliberate --
+    # major upgrades are planned, human-present operations -- but it means this
+    # `ignore_changes` has to be removed for the duration of one. See docs/runbooks/deploy.md.
+    ignore_changes = [engine_version]
+  }
+
   # ── Encryption at rest: DELIBERATELY NOT ENABLED (decided 2026-09-01, Tarig) ───────────
   # NOTE TO ANY FUTURE READER, HUMAN OR AGENT: do NOT "helpfully" add `storage_encrypted`
   # here. Its absence is a recorded decision, not an oversight, and enabling it is NOT a
@@ -105,4 +123,10 @@ resource "aws_rds_cluster_instance" "main" {
   instance_class     = "db.serverless"
   engine             = aws_rds_cluster.main.engine
   engine_version     = aws_rds_cluster.main.engine_version
+
+  lifecycle {
+    # Mirrors the cluster (ERR-012): the instance inherits the cluster's version, so it
+    # inherits the same fight with AWS auto-minor-upgrade.
+    ignore_changes = [engine_version]
+  }
 }


### PR DESCRIPTION
Follow-up to #37. The major-only pin does **not** suppress the diff on this provider — verified against the live stack, it still plans `16.11 -> "16"`, which issues a real `ModifyDBCluster`. Probably a no-op on a cluster already at 16.11, but that is not a good enough basis for an unplanned modification of a production database mid-deploy.

Adds `lifecycle { ignore_changes = [engine_version] }` to the cluster **and** its instance (the instance inherits the cluster's version, so it inherits the same fight).

The `engine_version = "16"` literal stays and is still load-bearing — it governs cluster **creation**, so a fresh apply after the destroy cadence still lands on 16.x for Data API + scale-to-0 + pgvector. The ignore only stops Terraform re-asserting on an **existing** cluster.

**Documented caveat:** a MAJOR upgrade will not apply while this is here. Deliberate, but it must be lifted for the duration of one — added as runbook §6 with the full procedure.

**Result:** `terraform plan` is now `0 to add, 2 to change, 0 to destroy` — the two Lambda functions and nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)