### PR TITLE
fix(repo): paginate every bulk read + size the scoring timeout to its reasoning effort (ERR-013)

### DIFF
--- a/docs/ledgers/backlog.md
+++ b/docs/ledgers/backlog.md
@@ -135,4 +135,18 @@ So **~280 scored jobs are unreachable from the email** — the still-open overfl
 
 **Connections:** [ERR-010](errors.md) / [ERR-011](errors.md) (found during the same close-out) · `.pre-commit-config.yaml` · [procedure-registry](procedure-registry.md) (`ruff-format` deferred).
 
+---
+
+## B-9 · A retrying LLM call can still outlive the deadline guard
+
+**Logged:** 2026-09-01, while sizing the scoring timeout ([ERR-013](errors.md)). **Status:** open, bounded, not urgent. Not built.
+
+**What.** The H-2 deadline guard checks `deadline.expired` **before starting** a call, never during one, so a call begun a moment before the wall runs its full timeout past it. `_DEADLINE_MARGIN_S` is now 200 s to cover a single 180 s scoring call — but the transport retries transients up to `max_retries=3`, so the true worst case is **4 x 180 s plus backoff ≈ 12 minutes** past the wall. Against a 900 s Lambda that is a hard timeout instead of the clean `partial` return H-2 exists to guarantee.
+
+**Why it matters (mildly).** It needs a genuinely transient failure (429/5xx/connection) on a call that starts in the last moments of a run — rare, and the consequence is a lost run rather than lost data, since every stage is idempotent and the `run_log` blocks a double digest. But it silently defeats the one guarantee the deadline guard makes, so it should not stay unnamed.
+
+**So-what.** (a) Give the *retry loop* a deadline, not just the task: pass the `Deadline` into `OpenAICompatLlmClient` and stop retrying once expired — the smallest honest fix. (b) Derive `_DEADLINE_MARGIN_S` from `(max_retries + 1) * timeout_s` instead of hand-tuning it, so the two can never drift apart again. (c) Cap total in-flight time per posting rather than per attempt. (a) is probably right; (b) is a good companion because the coupling is exactly what ERR-013 showed people get wrong.
+
+**Connections:** [ERR-013](errors.md) (raised the timeout that exposed this) · [ADR-0021](../adr/0021-m1-pipeline-hardening.md) (H-2, the deadline guard) · [ADR-0037](../adr/0037-per-task-reasoning-budgets.md) (reasoning effort and timeout are coupled).
+
 > **How this feeds the roadmap:** when the current program closes and P2 reopens, these entries are ranked (leverage = capability ÷ complexity) alongside the [roadmap](../03-roadmap.md) candidates (M2 dedup, M3 Step Functions, near-miss M4, CV tailoring). A graduated entry becomes a labeled release; a rejected one stays here with the reasoning.

--- a/src/jobfetcher/adapters/repository_postgres.py
+++ b/src/jobfetcher/adapters/repository_postgres.py
@@ -79,13 +79,16 @@ _DISSECTED_COLUMNS = (
     tables.posting.c.dissection_model,
     tables.posting.c.dropped_skill_count,
 )
-# Rows per Data API round-trip for the bulk silver read (ERR-013).
+# Rows per Data API round-trip for EVERY bulk read (ERR-013).
 # Projection alone was NOT enough. The 1 MB cap applies to the SERIALIZED JSON RESPONSE, and
 # `pg_column_size()` — which the first fix was sized on — reports the COMPRESSED ON-DISK size.
 # Measured live on 1,041 silver rows: the `skills` JSONB is 537 kB on disk but **1,291 kB as
 # text**, which is what actually crosses the wire. So the projected read was still ~1.4 MB and
 # still died. 200 rows/page is ~5x under the observed wall (1,000 rows passed, 1,041 failed).
-_SILVER_PAGE_SIZE = 200
+# Applied to every bulk read, not just the one that happened to fail first: the gold read blew
+# up at 781 rows the moment the silver read was fixed. Fixing them one at a time is whack-a-mole
+# on a shared root cause.
+_PAGE_SIZE = 200
 
 _SILVER_COLUMNS = (tables.posting.c.posting_id, *_DISSECTED_COLUMNS)
 _GOLD_COLUMNS = (
@@ -93,6 +96,38 @@ _GOLD_COLUMNS = (
     tables.posting.c.cluster_id,
     *_DISSECTED_COLUMNS,
 )
+
+
+
+def _read_paginated(conn, stmt, key_col, *, key: str = "posting_id", limit: int | None = None):
+    """Execute `stmt` as a KEYSET-paginated walk and return every row.
+
+    The Data API has no cursor and caps each RESPONSE at 1 MB, so any read whose size scales
+    with the table is a time bomb (ERR-010, ERR-013). Walking a unique key in fixed-size pages
+    makes each round-trip bounded by page size instead, whatever the table does.
+
+    The caller's `ORDER BY` is REPLACED by the keyset order — pagination requires ordering on
+    the key being walked. A caller that needs a different output order must sort the returned
+    rows itself; at these row counts that is free, and it keeps the keyset simple and correct
+    (a mixed-direction compound key cannot be expressed as a single row comparison anyway).
+
+    `OFFSET` is deliberately not used: it re-scans on every page, and it silently skips rows if
+    the underlying set shifts mid-walk.
+    """
+    rows: list = []
+    after = ""
+    base = stmt.order_by(None).order_by(key_col)
+    while True:
+        remaining = None if limit is None else limit - len(rows)
+        if remaining is not None and remaining <= 0:
+            break
+        page = _PAGE_SIZE if remaining is None else min(_PAGE_SIZE, remaining)
+        got = conn.execute(base.where(key_col > after).limit(page)).mappings().all()
+        if not got:
+            break
+        rows.extend(got)
+        after = got[-1][key]
+    return rows
 
 
 class PostgresRepository:
@@ -292,34 +327,13 @@ class PostgresRepository:
             where = where | (
                 (p.c.status == "rejected") & p.c.gold_filter_hash.is_distinct_from(filter_hash)
             )
-        # KEYSET pagination (ERR-013): the Data API has no cursor and caps each RESPONSE at
-        # 1 MB, so an unbounded read is unbounded by the size of the table — a time bomb whose
-        # fuse is the growth rate. Walking `posting_id` in pages keeps every round-trip small
-        # regardless of how large the backlog gets, and the caller still receives the whole
-        # set. Ordering is what makes the keyset stable; OFFSET is deliberately not used (it
-        # re-scans, and it skips rows if the set shifts mid-walk).
-        out: list[tuple[str, DissectedPosting]] = []
-        after = ""
+        stmt = select(*_SILVER_COLUMNS).where(where)
         try:
             with self.engine.connect() as conn:
-                while True:
-                    remaining = None if limit is None else limit - len(out)
-                    if remaining is not None and remaining <= 0:
-                        break
-                    page = _SILVER_PAGE_SIZE if remaining is None else min(_SILVER_PAGE_SIZE, remaining)
-                    stmt = (
-                        select(*_SILVER_COLUMNS)
-                        .where(where & (p.c.posting_id > after))
-                        .order_by(p.c.posting_id)
-                        .limit(page)
-                    )
-                    rows = conn.execute(stmt).mappings().all()
-                    if not rows:
-                        break
-                    out.extend((r["posting_id"], _dissected_from_row(r)) for r in rows)
-                    after = rows[-1]["posting_id"]
+                rows = _read_paginated(conn, stmt, p.c.posting_id, limit=limit)
         except SQLAlchemyError as e:
             raise RepositoryError(f"get_silver_postings failed: {e}") from e
+        out = [(r["posting_id"], _dissected_from_row(r)) for r in rows]
         return out
 
     def mark_gold_rejected(self, posting_id: str, *, filter_hash: str) -> None:
@@ -391,14 +405,11 @@ class PostgresRepository:
 
     def get_gold_candidates(self) -> list[tuple[str, str, DissectedPosting]]:
         # Ordered by posting_id so a scoring run is deterministic (re-runs visit the same order).
-        stmt = (
-            select(*_GOLD_COLUMNS)
-            .where(tables.posting.c.status == "gold_candidate")
-            .order_by(tables.posting.c.posting_id)
-        )
+        stmt = select(*_GOLD_COLUMNS).where(tables.posting.c.status == "gold_candidate")
         try:
             with self.engine.connect() as conn:
-                rows = conn.execute(stmt).mappings().all()
+                # Paginated (ERR-013): this read blew the 1 MB cap at 781 candidates.
+                rows = _read_paginated(conn, stmt, tables.posting.c.posting_id)
         except SQLAlchemyError as e:
             raise RepositoryError(f"get_gold_candidates failed: {e}") from e
         return [
@@ -459,10 +470,10 @@ class PostgresRepository:
             joined = joined.outerjoin(b, p.c.bronze_id == b.c.bronze_id)
             # A COALESCE'd NULL is INCLUDED (see docstring) — the OR IS NULL is load-bearing.
             stmt = stmt.where(age_source.is_(None) | (age_source >= cutoff))
-        stmt = stmt.select_from(joined).where(p.c.status == "scored").order_by(p.c.posting_id)
+        stmt = stmt.select_from(joined).where(p.c.status == "scored")
         try:
             with self.engine.connect() as conn:
-                rows = conn.execute(stmt).mappings().all()
+                rows = _read_paginated(conn, stmt, p.c.posting_id)  # ERR-013
         except SQLAlchemyError as e:
             raise RepositoryError(f"get_scored_for_reassess failed: {e}") from e
         return [
@@ -760,7 +771,6 @@ class PostgresRepository:
                     b, p.c.bronze_id == b.c.bronze_id
                 )
             )
-            .order_by(s.c.score.desc())
         )
         if max_age_days is not None and max_age_days > 0:
             cutoff = datetime.now(timezone.utc) - timedelta(days=max_age_days)
@@ -770,9 +780,12 @@ class PostgresRepository:
             joined = joined.where(age_source.is_(None) | (age_source >= cutoff))
         try:
             with self.engine.connect() as conn:
-                rows = conn.execute(joined).mappings().all()
+                # Paginated (ERR-013) on posting_id, then ordered here: the keyset must walk a
+                # unique key, so score-DESC ordering moves to Python. Free at these row counts.
+                rows = _read_paginated(conn, joined, p.c.posting_id)
         except SQLAlchemyError as e:
             raise RepositoryError(f"get_scored_shortlist failed: {e}") from e
+        rows = sorted(rows, key=lambda r: (-(r["score"] or 0), r["posting_id"]))
 
         surfaced: list[ShortlistItem] = []
         below = 0
@@ -860,16 +873,17 @@ class PostgresRepository:
                     b, p.c.bronze_id == b.c.bronze_id
                 )
             )
-            .order_by(s.c.score.desc(), p.c.posting_id)
         )
         if max_age_days is not None and max_age_days > 0:
             cutoff = datetime.now(timezone.utc) - timedelta(days=max_age_days)
             stmt = stmt.where(age_source.is_(None) | (age_source >= cutoff))
         try:
             with self.engine.connect() as conn:
-                rows = conn.execute(stmt).mappings().all()
+                rows = _read_paginated(conn, stmt, p.c.posting_id)  # ERR-013
         except SQLAlchemyError as e:
             raise RepositoryError(f"get_all_scored failed: {e}") from e
+        # score DESC, posting_id ASC — the order the SQL used to produce (see _read_paginated).
+        rows = sorted(rows, key=lambda r: (-(r["score"] or 0), r["posting_id"]))
 
         out: list[ShortlistItem] = []
         for row in rows:

--- a/src/jobfetcher/handlers/pipeline.py
+++ b/src/jobfetcher/handlers/pipeline.py
@@ -96,8 +96,16 @@ def _score_llm_config() -> LlmConfig:
 
     `max_tokens=6144` is ~2.6× the observed ceiling. It costs nothing extra — with an explicit
     effort, usage does NOT expand to fill the budget (2,348 tokens at max_tokens=8192, 2,227 at
-    12,288, 1,334 at 16,384); only the uncapped setting did that. So this is pure headroom."""
-    return LlmConfig(model=_SCORE_MODEL, reasoning_effort="high", max_tokens=6144)
+    12,288, 1,334 at 16,384); only the uncapped setting did that. So this is pure headroom.
+
+    `timeout_s=180` because high effort is SLOW. Measured live, the same scoring call took
+    **34.5 s and 68.5 s** on consecutive attempts — the 60 s default timed out mid-flight, and
+    a client timeout is classed transient, so it burned up to four retries on a call that was
+    working perfectly (ERR-013 follow-up). Reasoning effort and request timeout are coupled:
+    raising one without the other converts *slow* into *failed*."""
+    return LlmConfig(
+        model=_SCORE_MODEL, reasoning_effort="high", max_tokens=6144, timeout_s=180.0
+    )
 
 
 _DEFAULT_SEARCH_CONFIG_PATH = "config/search_config.local.yml"
@@ -123,7 +131,13 @@ _EXPECTED_MIGRATION_HEAD = "0007_gold_filter_hash"
 
 # Seconds reserved before the Lambda's hard timeout: in-flight LLM calls + the tail of DB
 # writes + notify must finish inside this margin (H-2 deadline guard).
-_DEADLINE_MARGIN_S = 60.0
+# Sized to the SCORING timeout (180 s): the guard checks `expired` BEFORE starting a call,
+# never during one, so a call begun a moment before the wall runs its full timeout past it.
+# A margin smaller than that timeout means the Lambda can hard-timeout instead of returning
+# a clean `partial` — which is the one behaviour H-2 exists to guarantee.
+# Residual, unchanged: a call that RETRIES can still exceed this (up to 4 x timeout). That
+# tail is bounded only by the Lambda timeout itself; see backlog B-9.
+_DEADLINE_MARGIN_S = 200.0
 
 
 # --------------------------------------------------------------------------- pure helpers

--- a/tests/test_handler_helpers.py
+++ b/tests/test_handler_helpers.py
@@ -375,6 +375,7 @@ def test_score_config_keeps_reasoning_on_at_high_effort():
     assert cfg.reasoning is True            # scoring is judgment — and v0.11.0 was calibrated on it
     assert cfg.reasoning_effort == "high"   # postings word the same role very differently
     assert cfg.max_tokens == 6144           # ~2.6x the observed 2,348-token ceiling
+    assert cfg.timeout_s == 180.0           # high effort measured 68.5s; the 60s default timed out
 
 
 def test_the_two_stages_do_not_share_a_budget():

--- a/tests/test_integration_gold_read_size.py
+++ b/tests/test_integration_gold_read_size.py
@@ -280,9 +280,9 @@ def test_read_returns_every_row_across_page_boundaries(repo, prefix):
     This seeds more rows than one page holds and asserts every one comes back — a loop that
     stops after the first page, or one that never terminates, both fail here.
     """
-    from jobfetcher.adapters.repository_postgres import _SILVER_PAGE_SIZE
+    from jobfetcher.adapters.repository_postgres import _PAGE_SIZE
 
-    n = _SILVER_PAGE_SIZE + 37  # deliberately not a multiple of the page size
+    n = _PAGE_SIZE + 37  # deliberately not a multiple of the page size
     for i in range(n):
         _seed(repo, prefix, f"p{i:04d}")
 
@@ -295,13 +295,70 @@ def test_read_returns_every_row_across_page_boundaries(repo, prefix):
 def test_limit_is_honoured_across_pages(repo, prefix):
     # negative twin: `limit` must still cap the total, not the page — otherwise a caller asking
     # for 10 rows gets a full table walk, which is the failure mode in reverse.
-    from jobfetcher.adapters.repository_postgres import _SILVER_PAGE_SIZE
+    from jobfetcher.adapters.repository_postgres import _PAGE_SIZE
 
-    for i in range(_SILVER_PAGE_SIZE + 10):
+    for i in range(_PAGE_SIZE + 10):
         _seed(repo, prefix, f"p{i:04d}")
 
     # Count the WHOLE result, not the prefix-filtered slice: `limit` is a global cap, and
     # other modules' rows may sort ahead of this test's on a shared database.
     assert len(repo.get_silver_postings(limit=5)) == 5
     # and a limit larger than one page still walks past the boundary
-    assert len(repo.get_silver_postings(limit=_SILVER_PAGE_SIZE + 3)) == _SILVER_PAGE_SIZE + 3
+    assert len(repo.get_silver_postings(limit=_PAGE_SIZE + 3)) == _PAGE_SIZE + 3
+
+
+def _seed_scored(repo, prefix: str, name: str, score: int) -> str:
+    """A fully scored posting: bronze -> silver -> cluster -> gold -> score -> status='scored'."""
+    posting_id = _seed(repo, prefix, name)
+    repo.upsert_cluster(cluster_id=posting_id, representative_posting_id=posting_id)
+    repo.set_posting_cluster(posting_id, posting_id)
+    repo.save_score(
+        cluster_id=posting_id, score=score, fit_category="strong_fit",
+        strengths=["a"], gaps=["b"], strategic_assessment="x",
+        poster_type="direct", legitimacy_verified=True,
+        scoring_model="test", profile_hash="h", run_id="seed",
+    )
+    repo.mark_scored(posting_id)
+    return posting_id
+
+
+def test_gold_candidates_read_paginates(repo, prefix):
+    """The read that failed one stage after the silver read was fixed.
+
+    With silver paginated, the gold filter promoted 781 candidates and `get_gold_candidates`
+    then blew the same 1 MB cap. Every bulk read shares the root cause, so every bulk read is
+    paginated — this pins the one that actually bit.
+    """
+    from jobfetcher.adapters.repository_postgres import _PAGE_SIZE
+
+    n = _PAGE_SIZE + 23
+    for i in range(n):
+        pid = _seed(repo, prefix, f"g{i:04d}")
+        repo.upsert_cluster(cluster_id=pid, representative_posting_id=pid)
+        repo.set_posting_cluster(pid, pid)
+        repo.mark_gold_candidate(pid)
+
+    got = [pid for pid, _cid, _d in repo.get_gold_candidates() if pid.startswith(prefix)]
+    assert len(got) == n
+    assert len(set(got)) == n
+    assert got == sorted(got)
+
+
+def test_all_scored_keeps_score_desc_ordering_across_pages(repo, prefix):
+    """Ordering moved from SQL into Python when the read became keyset-paginated.
+
+    A keyset must walk a unique key, so `ORDER BY score DESC` could not survive in the query.
+    If the Python re-sort were dropped or written wrong, the digest and the full-list report
+    would silently reorder — no error, just a worse product. Scores here are deliberately
+    interleaved so posting_id order and score order disagree.
+    """
+    from jobfetcher.adapters.repository_postgres import _PAGE_SIZE
+
+    n = _PAGE_SIZE + 15
+    for i in range(n):
+        _seed_scored(repo, prefix, f"s{i:04d}", score=(i * 7) % 100)
+
+    mine = [it for it in repo.get_all_scored() if it.posting_id.startswith(prefix)]
+    assert len(mine) == n
+    scores = [it.score for it in mine]
+    assert scores == sorted(scores, reverse=True), "score DESC ordering was lost"


### PR DESCRIPTION
Follow-up to #39. The paginated silver read **worked** — the gold filter processed the whole backlog for the first time in 38 days:

```
stage=gold done {'silver': 1041, 'gold': 781, 'dropped': 260}
```

Both pagination and the rejection lineage are proven live. The run then died one stage later, same error, on `get_gold_candidates()` with 781 rows.

## Every bulk read, not one at a time

Fixing these individually is whack-a-mole: each read behind the Data API is bounded by table size, so the next one blows the moment the previous is fixed. All five now go through one `_read_paginated` helper — `get_silver_postings`, `get_gold_candidates`, `get_scored_for_reassess`, `get_scored_shortlist`, `get_all_scored`.

The helper **replaces** the caller's `ORDER BY`, because a keyset must walk a unique key. So `get_scored_shortlist` and `get_all_scored` sort in Python now — free at these row counts, and it avoids a mixed-direction compound keyset (`score DESC, posting_id ASC`) which cannot be expressed as a single row comparison anyway.

## Scoring timeout — a second, separate bug

Two live-scorer tests failed with `TimeoutError`. Not flaky: measured directly, the same call took **34.5 s and 68.5 s** against `timeout_s=60`. A client timeout is classed **transient**, so in production each would burn up to four retries on a call that was working fine.

- scoring `timeout_s`: 60 → **180**
- `_DEADLINE_MARGIN_S`: 60 → **200**

The margin matters because the H-2 guard checks `expired` *before* starting a call, never during one — so a call begun just before the wall runs its full timeout past it. A margin below the timeout means a hard Lambda timeout instead of the clean `partial` H-2 exists to guarantee.

## Tests

- Gold candidates paginate across page boundaries (the read that actually bit).
- **`get_all_scored` still returns score-DESC after the ordering moved out of SQL**, with scores deliberately interleaved so posting_id order and score order disagree. A dropped or wrong re-sort would silently reorder the digest with no error at all.

## Recorded, not fixed

**B-9:** a *retrying* call can still outlive the margin (up to 4 × timeout ≈ 12 min). That needs the retry loop itself to be deadline-aware — a real change, not one to make while chasing a deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
