### PR TITLE
ops(lambda): raise PIPELINE_MAX_WORKERS 8 → 80 to drain the ERR-010 backlog (temporary)

### DIFF
--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -64,6 +64,23 @@ resource "aws_lambda_function" "pipeline" {
       # Telemetry verbosity for the `jobfetcher` package logger (ERR-009 rider) — the code
       # defaults to INFO when unset; this entry just makes the knob IaC-visible.
       LOG_LEVEL = "INFO"
+      # ⚠️ TEMPORARY — raised 8 -> 80 to drain the ERR-010 backlog. REVERT TO 8 (or delete
+      # this line) once `gold_candidate` reaches 0.
+      #
+      # H-2 concurrency: the size of the dissect/score ThreadPoolExecutor, i.e. how many LLM
+      # calls are in flight at once INSIDE ONE INVOCATION (not a number of invocations).
+      # Threads here are almost entirely blocked on the network, and every DB write stays on
+      # the main thread, so raising this adds no thread-safety surface.
+      #
+      # Why 80 is safe: `deepseek-v4-pro` caps at 500 CONCURRENT requests account-wide (no RPM
+      # cap; over the cap is a hard 429, no queue). 80 is 16% of that. Why 80 is enough: the
+      # 698-posting backlog needs 67 workers to fit in one run's ~687 s scoring window, at the
+      # measured ~73.5 s/posting/worker. The real ceiling above ~80 is not DeepSeek, it is the
+      # main-thread write path (~9.3 saves/sec over the Data API).
+      #
+      # The daily 10-30 job run needs none of this — leaving it high is standing risk for no
+      # benefit, which is why this is temporary.
+      PIPELINE_MAX_WORKERS = "80"
       # INV-001: the capture endpoint the "Mark applied" links point at + the signing-key secret
       # name. The pipeline signs the links (build_capture_link); the capture Lambda verifies them.
       # An empty CAPTURE_BASE_URL would just disable the links (graceful) — here it is always set.


### PR DESCRIPTION
**Temporary — reverts to 8 once `gold_candidate` reaches 0.**

The 38-day outage left **698 gold candidates unscored**. At 8 workers a run clears ~83 before the deadline guard returns `partial`, and `notify` deliberately refuses to send on a partial run — so no digest until the backlog clears: ~9 runs, about 2 hours, or 8 days on the daily cron.

**No code change.** `PIPELINE_MAX_WORKERS` was already wired and validated in `resolve_max_workers`; it was simply never set on the deployed function.

## Sized from the actual limit, not from caution

`deepseek-v4-pro` caps at **500 concurrent requests**, account-wide. There is **no RPM cap**; over the cap is a hard 429 with no queue, and no `x-ratelimit-*` headers exist to observe usage (verified against the account).

The backlog needs **698 ÷ 10.4 = 67 workers** to fit inside one run's ~687 s scoring window, at the measured ~73.5 s per posting per worker. **80** gives margin and is **16% of the cap**, leaving 420 slots unused.

Rate limiting is therefore not the binding constraint at any level worth using. What binds above ~80 is our own **main-thread write path** (~9.3 saves/sec over the Data API) — and that degrades into *slower*, not *broken*.

## It also costs nothing

Lambda bills duration × memory, so one 13-minute run costs the same at 8 threads or 80 — collapsing 9 runs into 1 is **~9× cheaper**. Total DeepSeek spend is unchanged; the same 698 postings get scored either way, just compressed into less wall clock.

## Note on what a "worker" is

80 workers is **80 threads inside a single invocation**, not 80 invocations. Threads are near-permanently blocked on the network, and every DB write stays on the main thread (H-2), so this adds no thread-safety surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)