### PR TITLE
fix(scoring): count billing failures separately, as dissection already did (ERR-011 gap)

### DIFF
--- a/src/jobfetcher/core/ingest.py
+++ b/src/jobfetcher/core/ingest.py
@@ -590,6 +590,7 @@ def score_gold(
 
     candidates = repo.get_gold_candidates()
     scored = 0
+    billing_blocked = 0
     surfaced = 0
     failed = 0
     deferred = 0
@@ -610,6 +611,12 @@ def score_gold(
                 resample_n=resample_n,
                 deadline=deadline,
             )
+        except LlmBillingError:
+            # NOT per-item: the account is empty, so this is identical for every posting in
+            # the run. Counted and logged once by the caller (ERR-011 — the same treatment
+            # dissection already had; scoring was the half that got missed, which is how a
+            # run reported `failed: 618` when it meant `billing_blocked: 618`).
+            return _BILLING_BLOCKED
         except (ScorerError, LlmError) as exc:
             log.warning("scoring failed for %s (run_id=%s): %s", posting_id, run_id, exc)
             return None
@@ -621,6 +628,9 @@ def score_gold(
                 result = fut.result()
                 if result is _DEFERRED:
                     deferred += 1
+                    continue
+                if result is _BILLING_BLOCKED:
+                    billing_blocked += 1
                     continue
                 if result is None:
                     failed += 1
@@ -669,12 +679,21 @@ def score_gold(
             deferred,
         )
 
+    if billing_blocked:
+        # ONE line, at ERROR, naming the operator action — not %d identical warnings.
+        log.error(
+            "LLM ACCOUNT OUT OF CREDIT (run_id=%s): %d scoring call(s) blocked by HTTP 402. "
+            "Top up the provider account — no retry or re-run will clear this.",
+            run_id,
+            billing_blocked,
+        )
     return {
         "gold": len(candidates),
         "scored": scored,
         "surfaced": surfaced,
         "failed": failed,
         "deferred": deferred,
+        "billing_blocked": billing_blocked,
     }
 
 
@@ -732,6 +751,7 @@ def reassess(
     downgraded = 0
     unchanged = 0
     failed = 0
+    billing_blocked = 0
     deferred = 0
     graduations: list[dict[str, Any]] = []
     deltas: list[int] = []  # |new − old| per successful reassess — the distribution input
@@ -752,6 +772,12 @@ def reassess(
                 resample_n=resample_n,
                 deadline=deadline,
             )
+        except LlmBillingError:
+            # NOT per-item: the account is empty, so this is identical for every posting in
+            # the run. Counted and logged once by the caller (ERR-011 — the same treatment
+            # dissection already had; scoring was the half that got missed, which is how a
+            # run reported `failed: 618` when it meant `billing_blocked: 618`).
+            return _BILLING_BLOCKED
         except (ScorerError, LlmError) as exc:
             log.warning("reassess scoring failed for %s (run_id=%s): %s", posting_id, run_id, exc)
             return None
@@ -763,6 +789,9 @@ def reassess(
                 result = fut.result()
                 if result is _DEFERRED:
                     deferred += 1
+                    continue
+                if result is _BILLING_BLOCKED:
+                    billing_blocked += 1
                     continue
                 if result is None:
                     failed += 1
@@ -867,6 +896,14 @@ def reassess(
         max_delta,
         mean_delta,
     )
+    if billing_blocked:
+        # ONE line, at ERROR, naming the operator action — not %d identical warnings.
+        log.error(
+            "LLM ACCOUNT OUT OF CREDIT (run_id=%s): %d scoring call(s) blocked by HTTP 402. "
+            "Top up the provider account — no retry or re-run will clear this.",
+            run_id,
+            billing_blocked,
+        )
     return {
         "reassessed": reassessed,
         "graduated": graduated,
@@ -874,6 +911,7 @@ def reassess(
         "unchanged": unchanged,
         "failed": failed,
         "deferred": deferred,
+        "billing_blocked": billing_blocked,
         "graduations": graduations,
         "delta_buckets": delta_buckets,
         "max_delta": max_delta,

--- a/tests/test_reassess.py
+++ b/tests/test_reassess.py
@@ -153,7 +153,7 @@ def test_reassess_defers_on_expired_deadline():
                       scorer=_CountingScorer(), deadline=Deadline(0))
     assert report == {
         "reassessed": 0, "graduated": 0, "downgraded": 0, "unchanged": 0,
-        "failed": 0, "deferred": 3, "graduations": [],
+        "failed": 0, "deferred": 3, "billing_blocked": 0, "graduations": [],
         # nothing reassessed → an all-zero distribution (honest zeros, keys still present)
         "delta_buckets": {"0-5": 0, "6-10": 0, "11-20": 0, "21+": 0},
         "max_delta": 0, "mean_delta": 0.0,

--- a/tests/test_scorer.py
+++ b/tests/test_scorer.py
@@ -19,7 +19,7 @@ from jobfetcher.core.scorer import (
     compute_code_total,
     subscores_payload,
 )
-from jobfetcher.core.ports import LlmError
+from jobfetcher.core.ports import LlmBillingError, LlmError
 from tests.helpers import FakeLlm
 
 
@@ -413,7 +413,7 @@ def test_vg8_threshold_0_surfaces_all():
     repo = _FakeScoreRepo(_profile_row(0), _candidates(), None)
     summary = score_gold(run_id="r", repo=repo, profile_hash="ph-unit",
                          scorer=_scorer_for([30, 65, 90]), max_workers=1)
-    assert summary == {"gold": 3, "scored": 3, "surfaced": 3, "failed": 0, "deferred": 0}
+    assert summary == {"gold": 3, "scored": 3, "surfaced": 3, "failed": 0, "deferred": 0, "billing_blocked": 0}
     assert all(v["fit_category"] == "strong_fit" for v in repo.saved.values())
 
 
@@ -457,7 +457,7 @@ def test_score_gold_skips_failed_scoring_and_continues():
     # max_workers=1: "the 2nd call" must map to p-mid deterministically (order-sensitive)
     summary = score_gold(run_id="r", repo=repo, profile_hash="ph-unit",
                          scorer=_OneBoomScorer(), max_workers=1)
-    assert summary == {"gold": 3, "scored": 2, "surfaced": 2, "failed": 1, "deferred": 0}
+    assert summary == {"gold": 3, "scored": 2, "surfaced": 2, "failed": 1, "deferred": 0, "billing_blocked": 0}
     assert repo.status["p-mid"] == "gold_candidate"  # the failed one is NOT marked scored
 
 
@@ -468,7 +468,7 @@ def test_score_gold_skips_llm_transport_error():
 
     repo = _FakeScoreRepo(_profile_row(60), [("p", "c", _dissected())], None)
     summary = score_gold(run_id="r", repo=repo, profile_hash="ph-unit", scorer=_BoomScorer())
-    assert summary == {"gold": 1, "scored": 0, "surfaced": 0, "failed": 1, "deferred": 0}
+    assert summary == {"gold": 1, "scored": 0, "surfaced": 0, "failed": 1, "deferred": 0, "billing_blocked": 0}
 
 
 def test_score_gold_defers_on_expired_deadline():
@@ -487,7 +487,7 @@ def test_score_gold_defers_on_expired_deadline():
     summary = score_gold(
         run_id="r", repo=repo, profile_hash="ph-unit", scorer=_CountingScorer(), deadline=Deadline(0)
     )
-    assert summary == {"gold": 3, "scored": 0, "surfaced": 0, "failed": 0, "deferred": 3}
+    assert summary == {"gold": 3, "scored": 0, "surfaced": 0, "failed": 0, "deferred": 3, "billing_blocked": 0}
     assert _CountingScorer.calls == 0
     assert repo.saved == {}  # nothing written
     assert all(v == "gold_candidate" for v in repo.status.values())  # nothing marked
@@ -670,3 +670,49 @@ def test_score_gold_resample_disabled_matches_today():
                resample_n=1)
     assert repo.saved["c-low"]["score"] == 62
     assert len(llm.calls) == 1
+
+
+def test_score_gold_counts_billing_failures_separately_and_logs_once(caplog):
+    """The half of ERR-011 that was missed, and what it cost.
+
+    Dissection already treated HTTP 402 as its own axis; scoring did not, so an empty account
+    surfaced as `failed: 618` — indistinguishable from 618 bad LLM responses — under 618
+    identical per-item warnings. That is the exact shape of the misdiagnosis that let a
+    38-day outage read as a model-quality problem.
+    """
+    class _BrokeScorer:
+        model_id = "test-model"
+
+        def score(self, dissected, profile):
+            raise LlmBillingError("402 Payment Required: Insufficient Balance")
+
+    repo = _FakeScoreRepo(_profile_row(60), _candidates(), None)
+    with caplog.at_level("WARNING"):
+        summary = score_gold(run_id="r", repo=repo, profile_hash="ph-unit",
+                             scorer=_BrokeScorer(), max_workers=1)
+
+    assert summary["billing_blocked"] == 3
+    assert summary["failed"] == 0      # NOT folded into the generic bucket
+    assert summary["scored"] == 0
+
+    # one line for three blocked postings, and it names the fix
+    billing = [r for r in caplog.records if "OUT OF CREDIT" in r.getMessage()]
+    assert len(billing) == 1
+    assert "Top up" in billing[0].getMessage()
+    # and no per-item noise for them
+    assert not [r for r in caplog.records if "scoring failed for" in r.getMessage()]
+
+
+def test_score_gold_billing_failure_leaves_postings_rescorable():
+    # negative twin: a posting blocked on billing must NOT be marked scored, or topping up
+    # would leave it silently skipped forever.
+    class _BrokeScorer:
+        model_id = "test-model"
+
+        def score(self, dissected, profile):
+            raise LlmBillingError("402")
+
+    repo = _FakeScoreRepo(_profile_row(60), _candidates(), None)
+    score_gold(run_id="r", repo=repo, profile_hash="ph-unit",
+               scorer=_BrokeScorer(), max_workers=1)
+    assert all(s == "gold_candidate" for s in repo.status.values())


### PR DESCRIPTION
ERR-011 made HTTP 402 legible in the **dissection** stage — its own error type, its own counter, one log line naming the operator action instead of one warning per posting. **Scoring never got the same treatment.**

So when the account emptied mid-drain:

```
stage=score done {'gold': 618, 'scored': 0, 'failed': 618}
```

`failed: 618` is indistinguishable from 618 bad LLM responses, buried under 618 identical per-item warnings. That is precisely the misdiagnosis shape that let a 38-day outage read as a model-quality problem — the thing ERR-011 exists to prevent, reproduced one stage over.

`score_gold` and `reassess` now catch `LlmBillingError` ahead of the generic handler, count it on its own axis, and log **one** line at ERROR. Both summaries gain `billing_blocked`.

## Tests

Three blocked postings ⇒ `billing_blocked: 3`, `failed: 0`, exactly one "OUT OF CREDIT" line, zero per-item warnings.

Plus a negative twin: a posting blocked on billing must stay `gold_candidate` and never be marked scored — otherwise topping up would leave it silently skipped forever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)