### PR TITLE
ops(lambda): revert concurrency to 8 — backlog drained; record the measured cost model (B-10)

### DIFF
--- a/docs/ledgers/backlog.md
+++ b/docs/ledgers/backlog.md
@@ -149,4 +149,34 @@ So **~280 scored jobs are unreachable from the email** — the still-open overfl
 
 **Connections:** [ERR-013](errors.md) (raised the timeout that exposed this) · [ADR-0021](../adr/0021-m1-pipeline-hardening.md) (H-2, the deadline guard) · [ADR-0037](../adr/0037-per-task-reasoning-budgets.md) (reasoning effort and timeout are coupled).
 
+---
+
+## B-10 · The real running cost is DeepSeek, not AWS — and it is unmeasured per run 💰
+
+**Logged:** 2026-09-02, from the ERR-010 backlog drain. **Status:** open — figures established, no instrumentation built. Requested by Tarig as a thing to be *aware of*, not to build yet.
+
+**What.** The architecture's cost story has always been about AWS ("Aurora scale-to-0 ⇒ ~$0 idle"). That framing is now wrong in the way that matters: **AWS is the cheap part.** The binding constraint on whether this tool runs tomorrow is the DeepSeek balance, and nothing in the pipeline measures or reports it.
+
+**Measured 2026-09-02** (balance read via `GET https://api.deepseek.com/user/balance` before and after a single run):
+
+| | |
+|---|---|
+| Postings scored | **618** |
+| Balance before → after | **$9.71 → $1.48** |
+| **Cost** | **$8.23** |
+| **Per posting** | **$0.0133** |
+| Wall clock | ~10 min at 80 workers |
+
+**Extrapolated to the daily run** (10–30 new postings): **$0.13–$0.40/day ⇒ roughly $4–12/month.** Against an AWS bill that is near zero at idle, DeepSeek is essentially the entire running cost of the product.
+
+**What drives it.** `reasoning_effort=high` on the scorer ([ADR-0037](../adr/0037-per-task-reasoning-budgets.md)). Measured token split per score: ~1,000–2,000 **reasoning** tokens against only ~270–340 tokens of actual answer — so **80–85% of scoring spend buys thinking that is discarded.** Dropping to `low` measured 886 reasoning tokens vs high's ~1,850, so it would roughly halve the bill. That is a real quality-vs-cost decision (and it would invalidate ADR-0031's calibration), not a free win — which is exactly why it belongs in a decision, not a tweak.
+
+Multiply by the [ADR-0031](../adr/0031-boundary-self-consistency-honest-graduations.md) boundary resample: a posting near the threshold is scored **3×**, so it costs ~$0.04 rather than $0.013. Roughly 1 in 5 postings qualify.
+
+**Why it matters.** Two failure modes, both seen today: (a) an empty balance stops the tool dead — 402 on every call, which is how the 38-day outage compounded; (b) a *low* balance silently throttles it, because DeepSeek scales concurrency with balance ([ERR-014](errors.md)) — 39 concurrent at ~empty, ≥200 at $10. So the balance is not just a bill, it is a **capacity input**, and it is invisible to every gate the project has.
+
+**So-what (candidates — none chosen).** (a) Report `usage` totals per run in the run summary and the S3 audit — the API already returns prompt/completion/reasoning counts per call, so this is accumulation, not new data. (b) A balance check in the `{"mode":"smoke"}` gate, failing or warning under a threshold — the deploy gate already exists and this is one HTTP call. (c) A CloudWatch alarm on a published balance metric — closes the "empty account" failure class properly, and is the only option that catches it *before* a run dies. (d) Reconsider `reasoning_effort` with the cost visible.
+
+**Connections:** [ERR-011](errors.md) / [ERR-014](errors.md) (both were balance failures wearing other costumes) · [ADR-0037](../adr/0037-per-task-reasoning-budgets.md) (the effort setting that drives the cost) · [ADR-0031](../adr/0031-boundary-self-consistency-honest-graduations.md) (the 3× resample multiplier) · [B-9](#) (the retry tail also spends).
+
 > **How this feeds the roadmap:** when the current program closes and P2 reopens, these entries are ranked (leverage = capability ÷ complexity) alongside the [roadmap](../03-roadmap.md) candidates (M2 dedup, M3 Step Functions, near-miss M4, CV tailoring). A graduated entry becomes a labeled release; a rejected one stays here with the reasoning.

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -64,24 +64,21 @@ resource "aws_lambda_function" "pipeline" {
       # Telemetry verbosity for the `jobfetcher` package logger (ERR-009 rider) — the code
       # defaults to INFO when unset; this entry just makes the knob IaC-visible.
       LOG_LEVEL = "INFO"
-      # ⚠️ TEMPORARY — raised to drain the ERR-010 backlog. REVERT TO 8 (or delete this
-      # line) once `gold_candidate` reaches 0.
+      # H-2 concurrency: the size of the dissect/score ThreadPoolExecutor — how many LLM calls
+      # are in flight at once INSIDE ONE INVOCATION (not a number of invocations). Back to the
+      # code default of 8 now that the ERR-010 backlog is drained; the daily 10-30 job run
+      # needs nothing more, and a high value is standing risk for no benefit.
       #
-      # H-2 concurrency: the size of the dissect/score ThreadPoolExecutor, i.e. how many LLM
-      # calls are in flight at once INSIDE ONE INVOCATION (not a number of invocations).
+      # BEFORE RAISING THIS AGAIN, read ERR-014. DeepSeek's concurrency limit is NOT the
+      # documented 500 — it is scaled to the account's REMAINING BALANCE, and it is reported
+      # only in the body of a 429 you have already triggered (no /limits endpoint, no
+      # x-ratelimit-* headers). Measured: 39 at a near-empty balance, >=200 at $10. So the safe
+      # value is a function of the balance on the day, not a constant.
+      #   check first:  GET https://api.deepseek.com/user/balance
       #
-      # 80, measured (ERR-014). Public docs say
-      # `deepseek-v4-pro` allows 500 concurrent. That is a CEILING, not an entitlement: the
-      # effective limit is scaled to the account's REMAINING BALANCE. At a near-empty balance
-      # it measured 39 (DeepSeek states the real number only in the 429 body — there is no
-      # /limits endpoint and no x-ratelimit-* header). After a $10 top-up, a burst probe of
-      # 200 concurrent requests drew zero 429s, so the limit is >= 200.
-      #
-      # 80 clears the whole 618-posting backlog in one run (~10.4 postings per worker per run)
-      # while sitting at <40% of a measured >=200. It is NOT a fixed safe value: if the balance
-      # is allowed to run down, the ceiling falls with it and this becomes too high again.
-      # Check `GET https://api.deepseek.com/user/balance` before raising it.
-      PIPELINE_MAX_WORKERS = "80"
+      # For reference, the 2026-09-02 drain ran 618 scorings at 80 workers in ~10 min for
+      # $8.23 — see backlog B-10 for the cost model.
+      PIPELINE_MAX_WORKERS = "8"
       # INV-001: the capture endpoint the "Mark applied" links point at + the signing-key secret
       # name. The pipeline signs the links (build_capture_link); the capture Lambda verifies them.
       # An empty CAPTURE_BASE_URL would just disable the links (graceful) — here it is always set.


### PR DESCRIPTION
**The ERR-010 backlog is gone:** `{'gold': 618, 'scored': 618, 'surfaced': 144, 'failed': 0, 'deferred': 0, 'billing_blocked': 0}`, `partial: False`.

80 → 8. The daily 10–30 job run needs nothing more, and a high value is standing risk for no benefit.

`lambda.tf` now carries the ERR-014 warning **at the point of temptation**: the limit is not the documented 500, it scales with remaining balance (39 at ~empty, ≥200 at $10), and it is only ever reported in a 429 you have already triggered. The safe value is a function of the balance that day.

## B-10 — the cost model, measured not estimated

Read the balance either side of one run:

| | |
|---|---|
| Postings scored | **618** |
| Balance | **$9.71 → $1.48** |
| **Cost** | **$8.23** |
| **Per posting** | **$0.0133** |

Extrapolated to 10–30 postings/day: **$0.13–0.40/day, ~$4–12/month.**

**The framing correction that matters:** the architecture's cost story has always been about AWS (*"scale-to-0 ⇒ ~$0 idle"*). AWS is the cheap part. **DeepSeek is essentially the entire running cost of the product, and nothing in the pipeline measures it.**

**80–85% of scoring spend is reasoning tokens that are then discarded** (~1,000–2,000 reasoning against ~270–340 of answer). So `reasoning_effort` is the cost lever — but changing it is a quality decision that would invalidate ADR-0031's calibration, not a tweak. Recorded, not acted on.

Also noted: **balance is a capacity input, not just a bill.** A low balance silently throttles concurrency; an empty one stops the tool dead. Both happened today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)