### PR TITLE
docs: the runnable docs, verified against code and the deployed stack (A1)

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -105,7 +105,7 @@ recipient_email = "<you@example.com>"         # verified in step 5 (sandbox need
 ```bash
 python scripts/build_lambda.py                 # package the Lambda (vendors Linux wheels; no Docker)
 terraform -chdir=terraform init                # connects to YOUR S3 backend
-terraform -chdir=terraform apply               # ~32 resources; also SEEDS your config/*.local.yml → S3
+terraform -chdir=terraform apply               # <!--fact:tf_resources-->32<!--/fact--> resources; also SEEDS your config/*.local.yml → S3
 
 # migrate the schema on Aurora, over the Data API. Grab the ARNs terraform just created:
 aws lambda get-function-configuration --function-name jobfetcher-dev-pipeline --region us-east-1 \
@@ -126,7 +126,9 @@ Then **confirm the SNS alarm email** AWS sends to your recipient address (click 
 AWS_MAX_ATTEMPTS=1 aws lambda invoke --function-name jobfetcher-dev-pipeline \
   --cli-binary-format raw-in-base64-out --cli-read-timeout 120 \
   --payload '{"mode":"smoke"}' smoke-out.json && cat smoke-out.json
-# → {"statusCode": 200, "mode": "smoke", "alembic_version": "0006_subscores", ...}   200 or you stop.
+# → {"statusCode": 200, "mode": "smoke", "alembic_version": "<!--gen:alembic_head-->0007_gold_filter_hash<!--/gen-->", ...}   200 or you stop.
+# The version above is generated from migrations/versions/ — if your run prints something
+# older, YOUR deploy is behind, not this doc. A 400 means exactly that mismatch.
 
 # a real run now (or just wait for the 06:00 UTC cron):
 AWS_MAX_ATTEMPTS=1 aws lambda invoke --function-name jobfetcher-dev-pipeline \
@@ -138,6 +140,42 @@ A `statusCode 200` and a **digest email** means you're live. *(New senders often
 ```bash
 python scripts/export.py            # → export/jobs.sqlite + jobs.csv — open in Datasette / DB Browser / Excel
 ```
+
+## 10b · What you just made public — read this before walking away
+
+`terraform apply` created **one internet-facing endpoint**: a second Lambda
+(`jobfetcher-dev-capture`) behind a **Lambda Function URL with `authorization_type = "NONE"`**.
+It backs the "✓ Mark applied" links in your digest, so one click from the inbox records an
+outcome ([ADR-0035](adr/0035-outcome-capture-endpoint.md) · [INV-001](investigations/INV-001-dark-feedback-loop/README.md)).
+
+**"NONE" means unauthenticated at the network layer — the auth is the token, not the URL.**
+Every request must carry a short-lived **HMAC signature** scoped to exactly one
+`{posting_id, status}` pair, with a 30-day TTL. Verification runs in constant time **before
+any database call**, so a forged, expired, or tampered token gets a `400` having written
+**zero rows**. The signing key is generated and owned by Terraform in Secrets Manager and
+never appears in outputs or logs.
+
+What that does and doesn't buy you:
+
+- **Bounded blast radius by design** — single-status, posting-scoped, expiring tokens; least-privilege IAM (Data API + its two secrets + Logs, nothing else); the account's 10-execution concurrency ceiling caps abuse. *(A per-function reservation was intended and removed at apply: AWS requires ≥10 unreserved, and the account limit is 10.)*
+- **One accepted trade-off, decided deliberately:** a one-click `GET` can be pre-fetched by an email security scanner, producing a spurious `applied`. The outcome log is append-only and `scripts/track.py override` corrects it; a confirmation interstitial is the documented fast-follow if it ever happens in practice.
+- **The URL is not in this repo on purpose.** Retrieve yours with:
+
+```bash
+aws lambda get-function-url-config --function-name jobfetcher-dev-capture   --region us-east-1 --query FunctionUrl --output text
+```
+
+If you would rather not expose it at all, remove `terraform/capture.tf` before your first
+`apply` — the pipeline runs without it and the digest simply renders no capture links (the
+renderers degrade to no-link when the base URL or key is missing). You lose outcome capture,
+which is what M7 scoring calibration is built on.
+
+### Your Secrets Manager will show four secrets, not two
+
+You created two (`jobfetcher/deepseek`, `jobfetcher/jsearch`). Terraform creates two more:
+`jobfetcher/capture-token` (the HMAC signing key above) and an `rds!cluster-…` entry — the
+Aurora master password, from `manage_master_user_password = true`, which both Lambdas read
+via `$DB_SECRET_ARN`. **Don't hand-delete the `rds!` one; it belongs to the cluster.**
 
 ## 11 · Teardown (back to ~$0)
 

--- a/docs/runbooks/deploy.md
+++ b/docs/runbooks/deploy.md
@@ -28,7 +28,7 @@ AWS_MAX_ATTEMPTS=1 aws lambda invoke --function-name jobfetcher-dev-pipeline \
   --payload '{"mode":"smoke"}' smoke-out.json && cat smoke-out.json
 ```
 
-- **PASS:** `{"statusCode": 200, "mode": "smoke", "alembic_version": "0007_gold_filter_hash", ...}` — the version must equal the `ALEMBIC_HEAD` env var terraform pinned (update both per migration: `lambda.tf` + `_EXPECTED_MIGRATION_HEAD` in `handlers/pipeline.py`; a unit test catches a stale constant).
+- **PASS:** `{"statusCode": 200, "mode": "smoke", "alembic_version": "<!--gen:alembic_head-->0007_gold_filter_hash<!--/gen-->", ...}` — the version must equal the `ALEMBIC_HEAD` env var terraform pinned (update both per migration: `lambda.tf` + `_EXPECTED_MIGRATION_HEAD` in `handlers/pipeline.py`; a unit test catches a stale constant).
 - **400** (`migration mismatch`): the DB is migrated, but to the **wrong head** → `alembic upgrade head`, re-invoke.
 - **500:** the Lambda can't reach the DB (Aurora paused + timeout, IAM, ARNs) — **or** the DB is reachable but was **never migrated at all** (missing/empty `alembic_version` table makes the SELECT itself fail). The `error` field tells them apart: an `UndefinedTable`/`NoResultFound` = run the first `alembic upgrade head`; a connect/timeout error = infra.
 - `AWS_MAX_ATTEMPTS=1` + `--cli-read-timeout 120` per the *invocation pattern* registry row (ERR-008: the CLI silently re-invokes slow sync calls); the smoke itself is one `SELECT`, but a scale-to-0 Aurora resume can take ~30 s.

--- a/scripts/sync_docs.py
+++ b/scripts/sync_docs.py
@@ -90,9 +90,24 @@ def gen_migrations() -> str:
     return ", ".join(f"`{n}`" for n in names)
 
 
+def gen_alembic_head() -> str:
+    """The newest migration's revision id — what a correct deploy reports.
+
+    Lives in three places for real (terraform/lambda.tf, handlers/pipeline.py, and
+    the migration files themselves — backlog B-7). This generator makes the DOC
+    copy follow the migration directory automatically; keeping the other two in
+    step is still B-7's job.
+    """
+    names = sorted(p.stem for p in (ROOT / "migrations" / "versions").glob("0*.py"))
+    if not names:
+        raise RuntimeError("no migrations found")
+    return names[-1]
+
+
 GENERATORS = {
     "current_release": ("the newest ## [vX.Y.Z] heading in CHANGELOG.md", gen_current_release),
     "migrations": ("migrations/versions/0*.py", gen_migrations),
+    "alembic_head": ("the newest migrations/versions/0*.py", gen_alembic_head),
 }
 
 


### PR DESCRIPTION
Doc-debt clearing, **PR 10**. `getting-started.md` + `runbooks/deploy.md` — the docs containing commands people actually run, so a wrong claim breaks someone's first hour.

## Two real defects

**1. The guide told newcomers to expect the wrong schema version.** It said `alembic_version: "0006_subscores"`. Verified three ways that it's `0007_gold_filter_hash`: the file on disk, `terraform/lambda.tf`, and the **live Lambda's `ALEMBIC_HEAD` env var**. A first-time deployer would have seen 0007, compared it to a doc saying 0006, and concluded their deploy was broken.

Now **generated** from `migrations/versions/` via a new `gen:alembic_head` block — in both the guide and the runbook — so it cannot drift again.

**2. Zero mention of the capture endpoint.** `terraform apply` creates a **public internet-facing write surface** and the clone-to-first-run guide never said so. New §10b covers what was made public, why `"NONE"` means the auth is the token rather than the network, the accepted GET-prefetch trade-off, how to retrieve your own URL (deliberately uncommitted), and **how to opt out** by removing `capture.tf` before the first apply — naming what that costs. Plus: your Secrets Manager will show **four** secrets, and the `rds!cluster-…` one must not be hand-deleted.

## The runbook needed almost nothing

Already at 0007, already documented B-7. Its §5/§6 claims were **verified rather than assumed**: `storage_encrypted` is genuinely absent from `terraform/aurora.tf` (live cluster confirms `StorageEncrypted: false`), and `ignore_changes = [engine_version]` is on both cluster and instance exactly as ERR-012 describes.

## Still unverified, stated plainly

I desk-checked and live-checked, but **nobody has run this guide from a clean clone on a fresh account.** SES verification, first-time bucket creation and the initial `apply` on an empty account are unproven by me. That's the one gap AWS access could not close.