### PR TITLE
fix(docs): the README's architecture diagram did not render on GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ flowchart LR
   SM -.-> CAP
   B -. raw .-> S3[("S3<br/>raw · audit · reports · config")]
   RPT -. presigned .-> S3
-  S & G & SC -. audit jsonl v0.12<br/>silver/gold/scores .-> S3
+  S & G & SC -. "audit jsonl v0.12<br/>silver/gold/scores" .-> S3
   H -. run summary → runs/ .-> S3
   B <--> PG[("Aurora Serverless v2<br/>+ RDS Data API")]
   S <--> PG

--- a/docs/02-architecture.md
+++ b/docs/02-architecture.md
@@ -20,7 +20,7 @@ flowchart TB
     SCORE <--> PG
     CV <--> PG
     NOTIFY <--> PG
-    DEDUP & SCORE -. audit jsonl v0.12\nsilver/gold/scores .-> S3
+    DEDUP & SCORE -. "audit jsonl v0.12<br/>silver/gold/scores" .-> S3
     NOTIFY -. report + run summary .-> S3
   end
   subgraph AN["ANALYTICAL PLANE — DE depth"]

--- a/scripts/check_docs.py
+++ b/scripts/check_docs.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python
 """Doc audit — the gate that keeps the repo honest about itself.
 
-WHAT: four checks over the markdown in this repo, run by CI on every PR.
+WHAT: five checks over the markdown in this repo, run by CI on every PR.
       (1) every internal link resolves
       (2) no unresolvable `plan §NN` citations
       (3) every *guarded* prose count agrees with the command that produces it
       (4) no stale "not yet deployed" claim on a shipped decision
+      (5) mermaid edge labels are quoted (an unquoted one renders as a red
+          error box on GitHub — it hit the README's own architecture diagram)
 
 WHY:  the project's first pillar is "the repo is the memory: any session resumes
       from these files alone." That was measurably false — see ERR-016. The debt
@@ -218,11 +220,55 @@ def check_stale_deploy() -> list[str]:
     return bad
 
 
+def check_mermaid_edge_labels() -> list[str]:
+    """Mermaid edge labels containing markup or slashes MUST be quoted.
+
+    WHY THIS EXISTS: two diagrams — including the README's front-page architecture — rendered
+    as a red "Unable to render rich display" box on GitHub for an unknown length of time, and
+    nobody noticed. Both were the same defect: an UNQUOTED edge label in the
+    `A -. text .-> B` form containing `<br/>` and `/`, which mermaid's lexer rejects.
+
+    This is a targeted heuristic, NOT a mermaid parser — it catches the shape that actually
+    broke, twice, with no new dependency. A full parse needs a node toolchain in CI (mermaid +
+    jsdom); that is a bigger call, and the validator used to find these lives in the PR notes.
+    Quoting an edge label is always safe, so the rule is simply: quote it.
+    """
+    edge = re.compile(
+        r"""(?:-\.|--|==)\s+          # a link opener followed by a bare label
+            (?!["|>])                 # already quoted / already a pipe-form label -> fine
+            ([^"|
+]*?)               # the label text
+            \s+(?:\.->|-->|==>)""",   # the closing arrow
+        re.X,
+    )
+    # Narrowed to angle brackets ONLY, and narrowed on evidence: the two real breakages both
+    # carried `<br/>`, while `run summary → runs/` and `errors / dead-man` were flagged by a
+    # wider rule and then confirmed FINE by an actual mermaid parse. A gate with false
+    # positives trains people to ignore it — which is the failure this repo keeps re-learning.
+    risky = re.compile(r"[<>]")
+    bad = []
+    for f in md_files():
+        text = f.read_text(encoding="utf-8", errors="replace")
+        for block in re.finditer(r"```mermaid\n(.*?)```", text, re.S):
+            start = text[: block.start()].count("\n") + 1
+            for i, line in enumerate(block.group(1).split("\n"), 1):
+                for m in edge.finditer(line):
+                    label = m.group(1).strip()
+                    if label and risky.search(label):
+                        bad.append(
+                            f"{rel(f)}:{start + i} — unquoted mermaid edge label "
+                            f"{label!r} contains markup (< or >); wrap it in double quotes "
+                            "or GitHub renders the whole diagram as an error box"
+                        )
+    return bad
+
+
 CHECKS = [
     ("internal links resolve", check_links),
     ("plan §NN citations are links", check_plan_refs),
     ("guarded counts match ground truth", check_facts),
     ("no stale deployment claims", check_stale_deploy),
+    ("mermaid edge labels are quoted", check_mermaid_edge_labels),
 ]
 
 


### PR DESCRIPTION
You spotted it on the repo's web page: a red **"Unable to render rich display"** box where the as-built architecture diagram should be — on the front page of a repo that exists partly to be read by hiring managers.

## Two diagrams were broken, not one

Found by **actually parsing them**, not reading them:

| File | What it is |
|---|---|
| `README.md:39` | the as-built architecture diagram — **the front page** |
| `docs/02-architecture.md:9` | the operational-plane diagram |

Same cause in both — an **unquoted** mermaid edge label containing markup:

```
S & G & SC -. audit jsonl v0.12<br/>silver/gold/scores .-> S3
```

Mermaid's lexer rejects the `<`, and **the whole diagram fails**, not just that edge. Fixed by quoting the label, which is always safe.

## Verified with a real parser

Extracted all **14** mermaid blocks in the repo and ran them through mermaid 11.17 under jsdom:

```
before: 14 diagrams, 2 broken
after:  14 diagrams, 0 broken
```

`docs/diagrams.md` — the canonical diagram file — was clean throughout, because it uses the quoted pipe form. The two broken ones were hand-written elsewhere.

## New gate — and how it was narrowed matters

`check_docs.py` now fails on an unquoted mermaid edge label containing markup.

**My first version also flagged slashes** — and caught two labels (`run summary → runs/`, `errors / dead-man`) that the real parser confirms are **fine**. Rather than ship a check with known false positives, which trains people to ignore it — the exact failure this repo keeps re-learning — I narrowed the rule to angle brackets only, on that evidence, and recorded the reasoning beside the code.

**Proven both ways:**
- 0 findings on the clean tree
- reintroducing the original line → exactly 1 finding, naming file, line and label
- restoring → green

It's a targeted heuristic, **not** a mermaid parser, and the docstring says so. A full parse needs a node toolchain in CI — a bigger call than this defect justifies.

<details>
<summary>The jsdom validator, if you ever want the full parse in CI</summary>

```js
import { JSDOM } from 'jsdom';
const dom = new JSDOM('<!doctype html><html><body></body></html>', { pretendToBeVisual: true });
for (const k of ['window','document','Element','HTMLElement','SVGElement','DOMParser','Node'])
  Object.defineProperty(globalThis, k, { value: dom.window[k] ?? dom.window, configurable: true, writable: true });
const mermaid = (await import('mermaid')).default;
mermaid.initialize({ startOnLoad: false, securityLevel: 'loose' });
await mermaid.parse(src);   // throws with file:line on a bad diagram
```
</details>
